### PR TITLE
use release build when ALLOC type is libc. 

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -124,7 +124,9 @@ pipeline {
 
                                 if ("${BUILD_TYPE}" == "release") {
                                     PRERELEASE = 'False'
-                                    BUILD_PROFILE = "test"
+                                    if ("${ALLOC}" != 'libc') {
+                                        BUILD_PROFILE = "test"
+                                    }
                                 }
 
                                 if (("${env.BRANCH_NAME}" =~ /PR-/) && ("$BUILD_TYPE" == "debug")) {


### PR DESCRIPTION
This flavor is required for OM