### PR TITLE
SDSTOR-xxxx add sg_list struct to sisl

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.50.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "8.3.4"
+    version = "8.3.5"
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"
     topics = ("ebay", "components", "core", "efficiency")

--- a/src/fds/CMakeLists.txt
+++ b/src/fds/CMakeLists.txt
@@ -57,6 +57,14 @@ target_sources(test_cb_mutex PRIVATE
 target_link_libraries(test_cb_mutex sisl ${COMMON_DEPS} GTest::gtest)
 #add_test(NAME TestCBMutex COMMAND test_cb_mutex)
 
+add_executable(test_sg_list)
+target_sources(test_sg_list PRIVATE
+    tests/test_sg_list.cpp
+  )
+target_link_libraries(test_sg_list sisl ${COMMON_DEPS} GTest::gtest)
+add_test(NAME SgList COMMAND test_sg_list)
+
+
 if (DEFINED MALLOC_IMPL)
     if (${MALLOC_IMPL} STREQUAL "jemalloc")
         add_executable(test_jemalloc)

--- a/src/fds/tests/test_sg_list.cpp
+++ b/src/fds/tests/test_sg_list.cpp
@@ -1,0 +1,41 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+
+#include <gtest/gtest.h>
+#include "sisl/fds/buffer.hpp"
+
+SISL_LOGGING_INIT(test_sg_list)
+SISL_OPTIONS_ENABLE(logging, test_sg_list)
+SISL_OPTION_GROUP(test_sg_list,
+                  (num_threads, "", "num_threads", "number of threads",
+                   ::cxxopts::value< uint32_t >()->default_value("8"), "number"))
+
+struct SgListTest : public testing::Test {};
+
+// a test case that make sure iterator works as expected;
+TEST_F(SgListTest, TestIterator) {
+    // TO Be Implemented;
+}
+
+int main(int argc, char* argv[]) {
+    int parsed_argc{argc};
+    ::testing::InitGoogleTest(&parsed_argc, argv);
+    SISL_OPTIONS_LOAD(parsed_argc, argv, logging, test_sg_list);
+    sisl::logging::SetLogger("test_sg_list");
+    spdlog::set_pattern("[%D %T%z] [%^%l%$] [%n] [%t] %v");
+
+    const auto ret{RUN_ALL_TESTS()};
+    return ret;
+}


### PR DESCRIPTION
This PR is to solve dependency of sg_list struct that is being used by different component so that they can be unblocked;
 
1. add sg_list to sisl
2. make sure it compiles with a test binary with a test case to be implemented later;