### PR TITLE
SDSTOR-8778 unaligned iov size test case

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.50.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "9.0.1"
+    version = "9.0.2"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/fds/buffer.hpp
+++ b/include/sisl/fds/buffer.hpp
@@ -40,16 +40,17 @@ struct blob {
     blob(uint8_t* const b, const uint32_t s) : bytes{b}, size{s} {}
 };
 
+using sg_iovs_t = folly::small_vector< iovec, 4 >;
 struct sg_list {
     uint64_t size; // total size of data pointed by iovs;
-    folly::small_vector< iovec > iovs;
+    sg_iovs_t iovs;
 };
 
 struct sg_iterator {
-    sg_iterator(const folly::small_vector< iovec >& v) : m_input_iovs{v} { assert(v.size() > 0); }
+    sg_iterator(const sg_iovs_t& v) : m_input_iovs{v} { assert(v.size() > 0); }
 
-    folly::small_vector< iovec > next_iovs(uint32_t size) {
-        folly::small_vector< iovec > ret_iovs;
+    sg_iovs_t next_iovs(uint32_t size) {
+        sg_iovs_t ret_iovs;
         uint64_t remain_size = size;
 
         while ((remain_size > 0) && (m_cur_index < m_input_iovs.size())) {
@@ -73,7 +74,7 @@ struct sg_iterator {
         return ret_iovs;
     }
 
-    const folly::small_vector< iovec >& m_input_iovs;
+    const sg_iovs_t& m_input_iovs;
     uint64_t m_cur_offset{0};
     size_t m_cur_index{0};
 };

--- a/include/sisl/fds/buffer.hpp
+++ b/include/sisl/fds/buffer.hpp
@@ -26,10 +26,11 @@
 #include <malloc.h>
 #include <sys/uio.h>
 #endif
-
+#include <folly/small_vector.h>
 #include <sisl/metrics/metrics.hpp>
 #include <sisl/utility/enum.hpp>
 #include "utils.hpp"
+
 namespace sisl {
 struct blob {
     uint8_t* bytes;
@@ -41,14 +42,14 @@ struct blob {
 
 struct sg_list {
     uint64_t size; // total size of data pointed by iovs;
-    std::vector< iovec > iovs;
+    folly::small_vector< iovec > iovs;
 };
 
 struct sg_iterator {
-    sg_iterator(const std::vector< iovec >& v) : m_input_iovs{v} { assert(v.size() > 0); }
+    sg_iterator(const folly::small_vector< iovec >& v) : m_input_iovs{v} { assert(v.size() > 0); }
 
-    std::vector< iovec > next_iovs(uint32_t size) {
-        std::vector< iovec > ret_iovs;
+    folly::small_vector< iovec > next_iovs(uint32_t size) {
+        folly::small_vector< iovec > ret_iovs;
         uint64_t remain_size = size;
 
         while ((remain_size > 0) && (m_cur_index < m_input_iovs.size())) {
@@ -72,7 +73,7 @@ struct sg_iterator {
         return ret_iovs;
     }
 
-    const std::vector< iovec >& m_input_iovs;
+    const folly::small_vector< iovec >& m_input_iovs;
     uint64_t m_cur_offset{0};
     size_t m_cur_index{0};
 };

--- a/src/fds/CMakeLists.txt
+++ b/src/fds/CMakeLists.txt
@@ -6,8 +6,7 @@ add_library(sisl_buffer OBJECT)
 target_sources(sisl_buffer PRIVATE
     buffer.cpp
   )
-  message("SISL_DEPS = ${SISL_DEPS}")
-  target_link_libraries(sisl_buffer Folly::Folly ${COMMON_DEPS})
+target_link_libraries(sisl_buffer Folly::Folly ${COMMON_DEPS})
 
 add_executable(test_stream_tracker)
 target_sources(test_stream_tracker PRIVATE

--- a/src/fds/CMakeLists.txt
+++ b/src/fds/CMakeLists.txt
@@ -6,7 +6,8 @@ add_library(sisl_buffer OBJECT)
 target_sources(sisl_buffer PRIVATE
     buffer.cpp
   )
-target_link_libraries(sisl_buffer ${COMMON_DEPS})
+  message("SISL_DEPS = ${SISL_DEPS}")
+  target_link_libraries(sisl_buffer Folly::Folly ${COMMON_DEPS})
 
 add_executable(test_stream_tracker)
 target_sources(test_stream_tracker PRIVATE

--- a/src/fds/tests/test_sg_list.cpp
+++ b/src/fds/tests/test_sg_list.cpp
@@ -24,9 +24,79 @@ SISL_OPTION_GROUP(test_sg_list,
 
 struct SgListTest : public testing::Test {};
 
-// a test case that make sure iterator works as expected;
-TEST_F(SgListTest, TestIterator) {
-    // TO Be Implemented;
+// the iterator request size is same as iov size for each iov;
+TEST_F(SgListTest, TestIteratorAlignedSize) {
+
+    std::vector< iovec > iovs;
+    iovs.push_back(iovec{nullptr, 1024});
+    iovs.push_back(iovec{nullptr, 512});
+    iovs.push_back(iovec{nullptr, 2048});
+    iovs.push_back(iovec{nullptr, 512});
+    uint32_t iov_size_total = 0;
+    for (const auto& v : iovs) {
+        iov_size_total += v.iov_len;
+    }
+
+    sisl::sg_list sg;
+    sg.size = iov_size_total;
+    sg.iovs = iovs;
+
+    sisl::sg_iterator sg_it{sg.iovs};
+    std::vector< uint32_t > bids_size_vec{1024, 512, 2048, 512};
+    uint32_t bids_size_total = 0;
+    for (const auto s : bids_size_vec) {
+        bids_size_total += s;
+    }
+
+    assert(iov_size_total == bids_size_total);
+
+    uint32_t itr_size_total = 0;
+    for (const auto& size : bids_size_vec) {
+        const auto iovs = sg_it.next_iovs(size);
+        for (const auto& iov : iovs) {
+            itr_size_total += iov.iov_len;
+        }
+    }
+
+    assert(itr_size_total == bids_size_total);
+}
+
+//
+// the iterator request size is unaligned with iov len, but total size is same;
+//
+TEST_F(SgListTest, TestIteratorUnalignedSize) {
+    std::vector< iovec > iovs;
+    iovs.push_back(iovec{nullptr, 1024});
+    iovs.push_back(iovec{nullptr, 512});
+    iovs.push_back(iovec{nullptr, 2048});
+    iovs.push_back(iovec{nullptr, 512});
+    uint32_t iov_size_total = 0;
+    for (const auto& v : iovs) {
+        iov_size_total += v.iov_len;
+    }
+
+    sisl::sg_list sg;
+    sg.size = iov_size_total;
+    sg.iovs = iovs;
+
+    sisl::sg_iterator sg_it{sg.iovs};
+    std::vector< uint32_t > bids_size_vec{512, 1024, 1024, 512, 512, 512};
+    uint32_t bids_size_total = 0;
+    for (const auto s : bids_size_vec) {
+        bids_size_total += s;
+    }
+
+    assert(iov_size_total == bids_size_total);
+
+    uint32_t itr_size_total = 0;
+    for (const auto& size : bids_size_vec) {
+        const auto iovs = sg_it.next_iovs(size);
+        for (const auto& iov : iovs) {
+            itr_size_total += iov.iov_len;
+        }
+    }
+
+    assert(itr_size_total == bids_size_total);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/fds/tests/test_sg_list.cpp
+++ b/src/fds/tests/test_sg_list.cpp
@@ -27,7 +27,7 @@ struct SgListTest : public testing::Test {};
 // the iterator request size is same as iov size for each iov;
 TEST_F(SgListTest, TestIteratorAlignedSize) {
 
-    folly::small_vector< iovec > iovs;
+    sisl::sg_iovs_t iovs;
     iovs.push_back(iovec{nullptr, 1024});
     iovs.push_back(iovec{nullptr, 512});
     iovs.push_back(iovec{nullptr, 2048});
@@ -42,7 +42,7 @@ TEST_F(SgListTest, TestIteratorAlignedSize) {
     sg.iovs = iovs;
 
     sisl::sg_iterator sg_it{sg.iovs};
-    folly::small_vector< uint32_t > bids_size_vec{1024, 512, 2048, 512};
+    std::vector< uint32_t > bids_size_vec{1024, 512, 2048, 512};
     uint32_t bids_size_total = 0;
     for (const auto s : bids_size_vec) {
         bids_size_total += s;
@@ -65,7 +65,7 @@ TEST_F(SgListTest, TestIteratorAlignedSize) {
 // the iterator request size is unaligned with iov len, but total size is same;
 //
 TEST_F(SgListTest, TestIteratorUnalignedSize) {
-    folly::small_vector< iovec > iovs;
+    sisl::sg_iovs_t iovs;
     iovs.push_back(iovec{nullptr, 1024});
     iovs.push_back(iovec{nullptr, 512});
     iovs.push_back(iovec{nullptr, 2048});
@@ -80,7 +80,7 @@ TEST_F(SgListTest, TestIteratorUnalignedSize) {
     sg.iovs = iovs;
 
     sisl::sg_iterator sg_it{sg.iovs};
-    folly::small_vector< uint32_t > bids_size_vec{512, 1024, 1024, 512, 512, 512};
+    std::vector< uint32_t > bids_size_vec{512, 1024, 1024, 512, 512, 512};
     uint32_t bids_size_total = 0;
     for (const auto s : bids_size_vec) {
         bids_size_total += s;

--- a/src/fds/tests/test_sg_list.cpp
+++ b/src/fds/tests/test_sg_list.cpp
@@ -27,7 +27,7 @@ struct SgListTest : public testing::Test {};
 // the iterator request size is same as iov size for each iov;
 TEST_F(SgListTest, TestIteratorAlignedSize) {
 
-    std::vector< iovec > iovs;
+    folly::small_vector< iovec > iovs;
     iovs.push_back(iovec{nullptr, 1024});
     iovs.push_back(iovec{nullptr, 512});
     iovs.push_back(iovec{nullptr, 2048});
@@ -42,7 +42,7 @@ TEST_F(SgListTest, TestIteratorAlignedSize) {
     sg.iovs = iovs;
 
     sisl::sg_iterator sg_it{sg.iovs};
-    std::vector< uint32_t > bids_size_vec{1024, 512, 2048, 512};
+    folly::small_vector< uint32_t > bids_size_vec{1024, 512, 2048, 512};
     uint32_t bids_size_total = 0;
     for (const auto s : bids_size_vec) {
         bids_size_total += s;
@@ -65,7 +65,7 @@ TEST_F(SgListTest, TestIteratorAlignedSize) {
 // the iterator request size is unaligned with iov len, but total size is same;
 //
 TEST_F(SgListTest, TestIteratorUnalignedSize) {
-    std::vector< iovec > iovs;
+    folly::small_vector< iovec > iovs;
     iovs.push_back(iovec{nullptr, 1024});
     iovs.push_back(iovec{nullptr, 512});
     iovs.push_back(iovec{nullptr, 2048});
@@ -80,7 +80,7 @@ TEST_F(SgListTest, TestIteratorUnalignedSize) {
     sg.iovs = iovs;
 
     sisl::sg_iterator sg_it{sg.iovs};
-    std::vector< uint32_t > bids_size_vec{512, 1024, 1024, 512, 512, 512};
+    folly::small_vector< uint32_t > bids_size_vec{512, 1024, 1024, 512, 512, 512};
     uint32_t bids_size_total = 0;
     for (const auto s : bids_size_vec) {
         bids_size_total += s;


### PR DESCRIPTION
1. add new test cases;
2. replace std::vector with folly::small_vector

Testing:
======
1. New test cases passed. 
Single GDB to test case and verified the aligned and unaligned size being returned by iterator is correct; 
Assert in the last step for total size accumulated;
2. Homestore build passed with this sisl package, make sure small_vector won't cause any issue. Also single gdb to the test case making sure small_vector provided `data()` api works as expected and called the correct version of vdev's async_writev. 
5. HomeRepl build passed with this sisl package also. 