### PR TITLE
Build all variants in GitHub

### DIFF
--- a/.github/workflows/build_with_conan.yml
+++ b/.github/workflows/build_with_conan.yml
@@ -69,7 +69,6 @@ jobs:
       with:
         path: |
           ~/.conan/data/folly
-          ~/.conan/data/spdlog
           ~/.conan/data/gperftools
           ~/.conan/data/jemalloc
           ~/.conan/data/prerelease_dummy

--- a/.github/workflows/build_with_conan.yml
+++ b/.github/workflows/build_with_conan.yml
@@ -64,7 +64,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Cache 3rdParty
-      id: cache-primes
+      id: cache-3rd-party
       uses: actions/cache@v3
       with:
         path: |
@@ -72,7 +72,8 @@ jobs:
           ~/.conan/data/spdlog
           ~/.conan/data/gperftools
           ~/.conan/data/jemalloc
-        key: ${{ matrix.build-type }}
+          ~/.conan/data/prerelease_dummy
+        key: ${{ matrix.build-type }}-${{ matrix.malloc-impl }}
 
     - name: Export Dependencies
       run: |

--- a/.github/workflows/build_with_conan.yml
+++ b/.github/workflows/build_with_conan.yml
@@ -23,15 +23,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8"]
+        # Currently folly in conan-center has a bug when used with gcc 11.3 and sanitizer
+        # sanitize: ["True", "False"]
         build-type: ["Debug", "Release"]
+        malloc-impl: ["libc", "tcmalloc", "jemalloc"]
+        prerelease: ["True", "False"]
+        exclude:
+          - build-type: Debug
+            prerelease: "True"
+          - build-type: Debug
+            malloc-impl: tcmalloc
+          - build-type: Debug
+            malloc-impl: jemalloc
+          - build-type: Release
+            malloc-impl: libc
+          # - build-type: Release
+          # sanitize: "True"
+          - prerelease: "True"
+            malloc-impl: jemalloc
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.8"
+
     - name: Install Conan
       run: |
         python -m pip install --upgrade pip
@@ -41,11 +57,27 @@ jobs:
       # Configure conan profiles for build runner
       run: |
         conan user
+        conan profile new --detect default
+        sed -i 's,compiler.libcxx=libstdc++$,compiler.libcxx=libstdc++11,g' ~/.conan/profiles/default
+
+    - name: Checkout Code
+      uses: actions/checkout@v3
+
+    - name: Export Dependencies
+      run: |
+        conan export 3rd_party/gperftools gperftools/2.7.0@
+        conan export 3rd_party/jemalloc jemalloc/5.2.1@
+        conan export 3rd_party/prerelease_dummy prerelease_dummy/1.0.1@
 
     - name: Install dependencies
       # Build your program with the given configuration
       run: |
-        conan install -o malloc_impl=libc -o prerelease=False -s build_type=${{ matrix.build-type }} --build missing .
+        conan install \
+            -o prerelease=${{ matrix.prerelease }} \
+            -o malloc_impl=${{ matrix.malloc-impl }} \
+            -s build_type=${{ matrix.build-type }} \
+            --build missing .
+            #-o sanitize=${{ matrix.sanitize }} \
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/build_with_conan.yml
+++ b/.github/workflows/build_with_conan.yml
@@ -72,6 +72,7 @@ jobs:
           ~/.conan/data/gperftools
           ~/.conan/data/jemalloc
           ~/.conan/data/prerelease_dummy
+          ~/.conan/data/spdlog
         key: ${{ matrix.build-type }}-${{ matrix.malloc-impl }}
 
     - name: Export Dependencies

--- a/.github/workflows/build_with_conan.yml
+++ b/.github/workflows/build_with_conan.yml
@@ -63,11 +63,22 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v3
 
+    - name: Cache 3rdParty
+      id: cache-primes
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.conan/data/folly
+          ~/.conan/data/spdlog
+          ~/.conan/data/gperftools
+          ~/.conan/data/jemalloc
+        key: ${{ matrix.build-type }}
+
     - name: Export Dependencies
       run: |
-        conan export 3rd_party/gperftools gperftools/2.7.0@
-        conan export 3rd_party/jemalloc jemalloc/5.2.1@
-        conan export 3rd_party/prerelease_dummy prerelease_dummy/1.0.1@
+        conan export 3rd_party/gperftools
+        conan export 3rd_party/jemalloc
+        conan export 3rd_party/prerelease_dummy
 
     - name: Install dependencies
       # Build your program with the given configuration

--- a/.github/workflows/build_with_conan.yml
+++ b/.github/workflows/build_with_conan.yml
@@ -81,7 +81,6 @@ jobs:
         conan export 3rd_party/prerelease_dummy
 
     - name: Install dependencies
-      # Build your program with the given configuration
       run: |
         conan install \
             -o prerelease=${{ matrix.prerelease }} \
@@ -89,6 +88,10 @@ jobs:
             -s build_type=${{ matrix.build-type }} \
             --build missing .
             #-o sanitize=${{ matrix.sanitize }} \
+
+    - name: Cleanup dep builds
+      run: |
+        rm -rf ~/.conan/data/*/*/*/*/build
 
     - name: Build
       # Build your program with the given configuration

--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -93,11 +93,22 @@ pipeline {
 */
         stage("Compile") {
             steps {
+                # For Sanitized Unit Testing (no publish)
                 sh "conan create ${BUILD_MISSING} -o ${PROJECT}:sanitize=True -pr debug . ${PROJECT}/${TAG}"
+                sh "conan remove -f ${PROJECT}/${TAG}"
+
+                # Debug/Release with libc for OM (disabled for now)
+                #sh "conan create ${BUILD_MISSING} -pr debug . ${PROJECT}/${TAG}"
+                #sh "conan create ${BUILD_MISSING} -pr test . ${PROJECT}/${TAG}"
+
+                # Debug w/ libc for downstream Sanitizer builds
                 sh "conan create ${BUILD_MISSING} -pr debug . ${PROJECT}/${TAG}"
-                sh "conan create ${BUILD_MISSING} -pr debug -o sisl:prerelease=False . ${PROJECT}/${TAG}"
-                sh "conan create ${BUILD_MISSING} -pr test . ${PROJECT}/${TAG}"
-                sh "conan create ${BUILD_MISSING} -pr test -o sisl:prerelease=False -pr test . ${PROJECT}/${TAG}"
+
+                # Pre-Release for Stability
+                sh "conan create ${BUILD_MISSING} -o malloc_impl=tcmalloc -o sisl:prerelease=True -pr test . ${PROJECT}/${TAG}"
+
+                # Release for Prod Build
+                sh "conan create ${BUILD_MISSING} -o malloc_impl=tcmalloc -pr test . ${PROJECT}/${TAG}"
             }
         }
 

--- a/3rd_party/gperftools/conanfile.py
+++ b/3rd_party/gperftools/conanfile.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, AutoToolsBuildEnvironment, tools
+
+class GPerfToolsConan(ConanFile):
+    name = "gperftools"
+    version = "2.7.0"
+    release = "2.7"
+    license = "BSD"
+
+    description = "A portable library to determine the call-chain of a C program"
+    settings = "os", "arch", "compiler", "build_type"
+
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = "shared=False", "fPIC=True"
+
+    requires = (("xz_utils/5.2.4"))
+
+    generators = "compiler_args"
+
+    def source(self):
+        source_url = "https://github.com/{0}/{0}/releases/download".format(self.name)
+        tools.get("{0}/{1}-{2}/{1}-{2}.tar.gz".format(source_url, self.name, self.release))
+
+    def build(self):
+        env_build = AutoToolsBuildEnvironment(self)
+        env_build.cxx_flags.append("@conanbuildinfo.args")
+        if self.settings.build_type != "Debug":
+            env_build.defines.append('NDEBUG')
+        configure_args = ['--disable-dependency-tracking', '--enable-libunwind']
+        if self.options.shared:
+            configure_args += ['--enable-shared=yes', '--enable-static=no']
+        else:
+            configure_args += ['--enable-shared=no', '--enable-static=yes']
+        env_build.configure(args=configure_args,configure_dir="{0}-{1}".format(self.name, self.release))
+        env_build.make(args=["-j1"])
+
+    def package(self):
+        headers = ['heap-checker.h', 'heap-profiler.h', 'malloc_extension.h', 'malloc_extension_c.h',
+                   'malloc_hook.h', 'malloc_hook_c.h', 'profiler.h', 'stacktrace.h', 'tcmalloc.h']
+        for header in headers:
+            self.copy("*{0}".format(header), dst="include/google", src="{0}-{1}/src/google".format(self.name, self.release), keep_path=False)
+            self.copy("*{0}".format(header), dst="include/gperftools", src="{0}-{1}/src/gperftools".format(self.name, self.release), keep_path=False)
+        self.copy("*.so*", dst="lib", keep_path=False, symlinks=True)
+        self.copy("*.a", dst="lib", keep_path=False, symlinks=True)
+
+    def package_info(self):
+        self.cpp_info.libs = ['tcmalloc_minimal']

--- a/3rd_party/jemalloc/conanfile.py
+++ b/3rd_party/jemalloc/conanfile.py
@@ -1,0 +1,195 @@
+from conans import AutoToolsBuildEnvironment, ConanFile, MSBuild, tools
+from conans.errors import ConanInvalidConfiguration
+from conans.client.tools import msvs_toolset
+import os
+import shutil
+import string
+
+
+class JemallocConan(ConanFile):
+    name = "jemalloc"
+    description = "jemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support."
+    url = "https://github.com/conan-io/conan-center-index"
+    license = "BSD-2-Clause"
+    homepage = "http://jemalloc.net/"
+    topics = ("conan", "jemalloc", "malloc", "free")
+    settings = "os", "arch", "compiler"
+    version = "5.2.1"
+    source_url = "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "prefix": "ANY",
+        "enable_cxx": [True, False],
+        "enable_fill": [True, False],
+        "enable_xmalloc": [True, False],
+        "enable_readlinkat": [True, False],
+        "enable_syscall": [True, False],
+        "enable_lazy_lock": [True, False],
+        "enable_debug_logging": [True, False],
+        "enable_initial_exec_tls": [True, False],
+        "enable_libdl": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "prefix": "",
+        "enable_cxx": True,
+        "enable_fill": True,
+        "enable_xmalloc": False,
+        "enable_readlinkat": False,
+        "enable_syscall": True,
+        "enable_lazy_lock": False,
+        "enable_debug_logging": False,
+        "enable_initial_exec_tls": True,
+        "enable_libdl": True,
+    }
+
+    _autotools = None
+
+    _source_subfolder = "source_subfolder"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.settings.compiler.get_safe("libcxx") == "libc++":
+            raise ConanInvalidConfiguration("libc++ is missing a mutex implementation.  Remove this when it is added")
+        if self.settings.compiler == "Visual Studio" and self.settings.compiler.version != "15":
+            # https://github.com/jemalloc/jemalloc/issues/1703
+            raise ConanInvalidConfiguration("Only Visual Studio 15 2017 is supported.  Please fix this if other versions are supported")
+        if self.options.shared:
+            del self.options.fPIC
+        if not self.options.enable_cxx:
+            del self.settings.compiler.libcxx
+            del self.settings.compiler.cppstd
+        if self.settings.compiler == "Visual Studio" and self.settings.arch not in ("x86_64", "x86"):
+            raise ConanInvalidConfiguration("Unsupported arch")
+
+    def source(self):
+        tools.get(self.source_url)
+        os.rename("{}-{}".format(self.name, self.version), self._source_subfolder)
+
+    def build_requirements(self):
+        if tools.os_info.is_windows and not os.environ.get("CONAN_BASH_PATH", None):
+            self.build_requires("msys2/20190524")
+
+    @property
+    def _autotools_args(self):
+        conf_args = [
+            "--with-jemalloc-prefix={}".format(self.options.prefix),
+            "--disable-debug",
+            "--enable-cxx" if self.options.enable_cxx else "--disable-cxx",
+            "--enable-fill" if self.options.enable_fill else "--disable-fill",
+            "--enable-xmalloc" if self.options.enable_cxx else "--disable-xmalloc",
+            "--enable-readlinkat" if self.options.enable_readlinkat else "--disable-readlinkat",
+            "--enable-syscall" if self.options.enable_syscall else "--disable-syscall",
+            "--enable-lazy-lock" if self.options.enable_lazy_lock else "--disable-lazy-lock",
+            "--enable-log" if self.options.enable_debug_logging else "--disable-log",
+            "--enable-initial-exec-tld" if self.options.enable_initial_exec_tls else "--disable-initial-exec-tls",
+            "--enable-libdl" if self.options.enable_libdl else "--disable-libdl",
+        ]
+        if self.options.shared:
+            conf_args.extend(["--enable-shared", "--disable-static"])
+        else:
+            conf_args.extend(["--disable-shared", "--enable-static"])
+        return conf_args
+
+    def _configure_autotools(self):
+        if self._autotools:
+            return self._autotools
+        self._autotools = AutoToolsBuildEnvironment(self, win_bash=tools.os_info.is_windows)
+        self._autotools.configure(args=self._autotools_args, configure_dir=self._source_subfolder)
+        return self._autotools
+
+    @property
+    def _msvc_build_type(self):
+        build_type = "Release"
+        if not self.options.shared:
+            build_type += "-static"
+        return build_type
+
+    def _patch_sources(self):
+        if self.settings.os == "Windows":
+            makefile_in = os.path.join(self._source_subfolder, "Makefile.in")
+            tools.replace_in_file(makefile_in,
+                                  "DSO_LDFLAGS = @DSO_LDFLAGS@",
+                                  "DSO_LDFLAGS = @DSO_LDFLAGS@ -Wl,--out-implib,lib/libjemalloc.a")
+            tools.replace_in_file(makefile_in,
+                                  "\t$(INSTALL) -d $(LIBDIR)\n"
+                                  "\t$(INSTALL) -m 755 $(objroot)lib/$(LIBJEMALLOC).$(SOREV) $(LIBDIR)",
+                                  "\t$(INSTALL) -d $(BINDIR)\n"
+                                  "\t$(INSTALL) -d $(LIBDIR)\n"
+                                  "\t$(INSTALL) -m 755 $(objroot)lib/$(LIBJEMALLOC).$(SOREV) $(BINDIR)\n"
+                                  "\t$(INSTALL) -m 644 $(objroot)lib/libjemalloc.a $(LIBDIR)")
+
+    def build(self):
+        self._patch_sources()
+        if self.settings.compiler == "Visual Studio":
+            with tools.vcvars(self.settings) if self.settings.compiler == "Visual Studio" else tools.no_op():
+                with tools.environment_append({"CC": "cl", "CXX": "cl"}) if self.settings.compiler == "Visual Studio" else tools.no_op():
+                    with tools.chdir(self._source_subfolder):
+                        # Do not use AutoToolsBuildEnvironment because we want to run configure as ./configure
+                        self.run("./configure {}".format(" ".join(self._autotools_args)), win_bash=tools.os_info.is_windows)
+            msbuild = MSBuild(self)
+            # Do not use the 2015 solution: unresolved external symbols: test_hooks_libc_hook and test_hooks_arena_new_hook
+            sln_file = os.path.join(self._source_subfolder, "msvc", "jemalloc_vc2017.sln")
+            msbuild.build(sln_file, targets=["jemalloc"], build_type=self._msvc_build_type)
+        else:
+            autotools = self._configure_autotools()
+            autotools.make()
+
+    @property
+    def _library_name(self):
+        libname = "jemalloc"
+        if self.settings.compiler == "Visual Studio":
+            if self.options.shared:
+                if "Release" == "Debug":
+                    libname += "d"
+            else:
+                toolset = msvs_toolset(self.settings)
+                toolset_number = "".join(c for c in toolset if c in string.digits)
+                libname += "-vc{}-{}".format(toolset_number, self._msvc_build_type)
+        else:
+            if self.settings.os == "Windows":
+                if not self.options.shared:
+                    libname += "_s"
+            else:
+                if not self.options.shared and self.options.fPIC:
+                    libname += "_pic"
+        return libname
+
+    def package(self):
+        self.copy(pattern="COPYING", src=self._source_subfolder, dst="licenses")
+        if self.settings.compiler == "Visual Studio":
+            arch_subdir = {
+                "x86_64": "x64",
+                "x86": "x86",
+            }[str(self.settings.arch)]
+            self.copy("*.lib", src=os.path.join(self._source_subfolder, "msvc", arch_subdir, self._msvc_build_type), dst=os.path.join(self.package_folder, "lib"))
+            self.copy("*.dll", src=os.path.join(self._source_subfolder, "msvc", arch_subdir, self._msvc_build_type), dst=os.path.join(self.package_folder, "bin"))
+            self.copy("jemalloc.h", src=os.path.join(self._source_subfolder, "include", "jemalloc"), dst=os.path.join(self.package_folder, "include", "jemalloc"), keep_path=True)
+            shutil.copytree(os.path.join(self._source_subfolder, "include", "msvc_compat"),
+                            os.path.join(self.package_folder, "include", "msvc_compat"))
+        else:
+            autotools = self._configure_autotools()
+            # Use install_lib_XXX and install_include to avoid mixing binaries and dll's
+            autotools.make(target="install_lib_shared" if self.options.shared else "install_lib_static")
+            autotools.make(target="install_include")
+            if self.settings.os == "Windows" and self.settings.compiler == "gcc":
+                os.rename(os.path.join(self.package_folder, "lib", "{}.lib".format(self._library_name)),
+                          os.path.join(self.package_folder, "lib", "lib{}.a".format(self._library_name)))
+                if not self.options.shared:
+                    os.unlink(os.path.join(self.package_folder, "lib", "jemalloc.lib"))
+
+    def package_info(self):
+        self.cpp_info.libs = [self._library_name]
+        self.cpp_info.includedirs = [os.path.join(self.package_folder, "include"),
+                                     os.path.join(self.package_folder, "include", "jemalloc")]
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.includedirs.append(os.path.join(self.package_folder, "include", "msvc_compat"))
+        if not self.options.shared:
+            self.cpp_info.defines = ["JEMALLOC_EXPORT="]
+        if self.settings.os == "Linux":
+            self.cpp_info.system_libs.extend(["dl", "pthread"])

--- a/3rd_party/prerelease_dummy/conanfile.py
+++ b/3rd_party/prerelease_dummy/conanfile.py
@@ -1,0 +1,23 @@
+from conans import ConanFile, CMake, tools
+
+class PrereleaseConan(ConanFile):
+    name = "prerelease_dummy"
+    version = "1.0.1"
+    homepage = "https://github.corp.ebay.com/SDS/prerelease_dummy"
+    description = "A dummy package to invoke PRERELEASE option"
+    topics = ("ebay", "nublox")
+    url = "https://github.corp.ebay.com/SDS/prerelease_dummy"
+    license = "Apache-2.0"
+
+    settings = ()
+
+    exports_sources = ("LICENSE")
+
+    def build(self):
+        pass
+
+    def package(self):
+        pass
+
+    def package_info(self):
+        self.cpp_info.cxxflags.append("-D_PRERELEASE=1")

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conan.tools.files import copy
 from conan.tools.build import check_min_cppstd
 from conans import CMake
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=1.52.0"
 
 class SISLConan(ConanFile):
     name = "sisl"

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,12 +33,18 @@ class SISLConan(ConanFile):
                 'coverage': False,
                 'testing': True,
                 'sanitize': False,
-                'prerelease': True,
-                'malloc_impl': 'tcmalloc',
+                'prerelease': False,
+                'malloc_impl': 'libc',
             }
 
     generators = "cmake", "cmake_find_package"
-    exports_sources = ("CMakeLists.txt", "cmake/*", "include/*", "src/*", "LICENSE")
+    exports = ["LICENSE"]
+    exports_sources = (
+                "CMakeLists.txt",
+                "cmake/*",
+                "include/*",
+                "src/*",
+            )
 
     def build_requirements(self):
         self.build_requires("benchmark/1.7.1")
@@ -86,6 +92,8 @@ class SISLConan(ConanFile):
             check_min_cppstd(self, 20)
 
     def configure(self):
+        if self.settings.compiler in ["gcc"]:
+            self.options['pistache'].with_ssl: True
         if self.options.shared:
             del self.options.fPIC
         if self.settings.build_type == "Debug":

--- a/include/sisl/fds/malloc_helper.hpp
+++ b/include/sisl/fds/malloc_helper.hpp
@@ -569,7 +569,7 @@ static void print_my_jemalloc_data(void* const opaque, const char* const buf) {
 #endif
 #endif
 
-[[maybe_unused]] static bool set_memory_release_rate(const double level) {
+[[maybe_unused]] static bool set_memory_release_rate([[maybe_unused]] const double level) {
 #if defined(USING_TCMALLOC)
     MallocExtension::instance()->SetMemoryReleaseRate(level);
     return true;
@@ -599,8 +599,8 @@ static std::atomic< bool > s_is_aggressive_decommit{false};
     return true;
 }
 
-[[maybe_unused]] static bool reset_aggressive_decommit_mem_if_needed(const size_t mem_usage,
-                                                                     const size_t aggressive_threshold) {
+[[maybe_unused]] static bool
+reset_aggressive_decommit_mem_if_needed([[maybe_unused]] const size_t mem_usage, [[maybe_unused]] const size_t aggressive_threshold) {
 #if defined(USING_TCMALLOC)
     if (tcmalloc_helper::s_is_aggressive_decommit.load(std::memory_order_acquire)) {
         LOGINFO("Total memory alloced={} is restored back to less than aggressive threshold limit {}, "
@@ -628,7 +628,7 @@ static std::atomic< bool > s_is_aggressive_decommit{false};
     return true;
 }
 
-[[maybe_unused]] static bool release_mem_if_needed(const size_t soft_threshold, const size_t aggressive_threshold_in) {
+[[maybe_unused]] static bool release_mem_if_needed([[maybe_unused]] const size_t soft_threshold, [[maybe_unused]] const size_t aggressive_threshold_in) {
     bool ret{false};
 #if defined(USING_TCMALLOC) || defined(USING_JEMALLOC) || defined(USE_JEMALLOC)
     size_t mem_usage{0};

--- a/src/fds/CMakeLists.txt
+++ b/src/fds/CMakeLists.txt
@@ -71,7 +71,7 @@ if (DEFINED MALLOC_IMPL)
         target_sources(test_jemalloc PRIVATE
             tests/test_jemalloc_helper.cpp
           )
-        target_link_libraries(test_jemalloc sisl ${COMMON_DEPS} jemalloc GTest::gtest)
+        target_link_libraries(test_jemalloc sisl ${COMMON_DEPS} GTest::gtest)
         add_test(NAME TestJemalloc COMMAND test_jemalloc)
     elseif (${MALLOC_IMPL} STREQUAL "tcmalloc")
         add_executable(test_tcmalloc)


### PR DESCRIPTION
- Missing dependencies (gperftools, jemalloc, prerelease, etc.) have recipes located in `3rd_party/<pkg_name>`
- CI logic to export each required dependency (should be script?)
- Added matrix columns for missing variants that work (sanitize no-go for now)
- Cache 3rd party libraries that rarely are updated