### PR TITLE
Platform support

### DIFF
--- a/.github/workflows/build_dependencies.yml
+++ b/.github/workflows/build_dependencies.yml
@@ -74,14 +74,6 @@ jobs:
   BuildSislDeps:
     runs-on: ${{ inputs.platform }}
     steps:
-    - name: Restore Sisl Cache
-      id: restore-cache-sisl
-      uses: actions/cache/restore@v3
-      with:
-        path: |
-          ~/.conan/data
-        key: SislDeps-${{ inputs.platform }}-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}
-
     - name: Retrieve Code
       uses: actions/checkout@v3
       with:
@@ -95,7 +87,18 @@ jobs:
         repository: ebay/sisl
         path: deps/sisl
         ref: ${{ inputs.branch }}
-      if: ${{ inputs.testing == 'False' && steps.restore-cache-sisl.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.testing == 'False' }}
+
+    - name: Restore Sisl Cache
+      id: restore-cache-sisl
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          ~/.conan/data
+        key: SislDeps-${{ inputs.platform }}-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}-${{ hashFiles('**/conanfile.py') }}
+        restore-keys: |
+          SislDeps-${{ inputs.platform }}-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-
+          SislDeps-${{ inputs.platform }}-
 
     - name: Setup Python
       uses: actions/setup-python@v3
@@ -160,5 +163,5 @@ jobs:
       with:
         path: |
           ~/.conan/data
-        key: SislDeps-${{ inputs.platform }}-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}
+        key: SislDeps-${{ inputs.platform }}-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}-${{ hashFiles('**/conanfile.py') }}
       if: ${{ github.event_name != 'pull_request' && steps.restore-cache-sisl.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build_dependencies.yml
+++ b/.github/workflows/build_dependencies.yml
@@ -3,6 +3,10 @@ name: Conan Build
 on:
   workflow_call:
     inputs:
+      platform:
+        required: false
+        default: 'ubuntu-22.04'
+        type: string
       branch:
         required: true
         type: string
@@ -22,6 +26,15 @@ on:
         default: 'False'
   workflow_dispatch:
     inputs:
+      platform:
+        required: true
+        type: choice
+        options:
+          - ubuntu-22.04
+          - ubuntu-20.04
+          - macos-13
+          - macos-12
+        default: 'ubuntu-22.04'
       branch:
         required: true
         type: string
@@ -49,17 +62,17 @@ on:
           - 'False'
         default: 'False'
       testing:
-        description: 'Run Tests'
+        description: 'Build and Run'
         required: true
         type: choice
         options:
           - 'True'
           - 'False'
-        default: 'False'
+        default: 'True'
 
 jobs:
   BuildSislDeps:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.platform }}
     steps:
     - name: Restore Sisl Cache
       id: restore-cache-sisl
@@ -67,7 +80,7 @@ jobs:
       with:
         path: |
           ~/.conan/data
-        key: SislDeps-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}
+        key: SislDeps-${{ inputs.platform }}-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}
 
     - name: Retrieve Code
       uses: actions/checkout@v3
@@ -96,12 +109,18 @@ jobs:
         python -m pip install conan~=1.0
         conan user
         conan profile new --detect default
-        # Set std::string to non-CoW C++11 version
-        sed -i 's,compiler.libcxx=libstdc++$,compiler.libcxx=libstdc++11,g' ~/.conan/profiles/default
         conan export deps/sisl/3rd_party/gperftools
         conan export deps/sisl/3rd_party/jemalloc
         conan export deps/sisl/3rd_party/prerelease_dummy
+        cached_pkgs=$(ls -1d ~/.conan/data/*/*/*/*/package | sed 's,.*data/,,' | cut -d'/' -f1,2 | paste -sd',' - -)
+        echo "::info:: Pre-cached: ${cached_pkgs}"
       if: ${{ inputs.testing == 'True' || steps.restore-cache-sisl.outputs.cache-hit != 'true' }}
+
+    - name: Fixup libstdc++
+      run: |
+        # Set std::string to non-CoW C++11 version
+        sed -i 's,compiler.libcxx=libstdc++$,compiler.libcxx=libstdc++11,g' ~/.conan/profiles/default
+      if: ${{ inputs.platform == 'ubuntu-22.04' && ( inputs.testing == 'True' || steps.restore-cache-sisl.outputs.cache-hit != 'true' ) }}
 
     - name: Build Cache
       run: |
@@ -111,7 +130,7 @@ jobs:
             -s build_type=${{ inputs.build-type }} \
             --build missing \
             deps/sisl
-      if: ${{ inputs.testing != 'True' && steps.restore-cache-sisl.outputs.cache-hit != 'true' }}
+      if: ${{ steps.restore-cache-sisl.outputs.cache-hit != 'true' }}
 
     - name: Test Package
       run: |
@@ -121,12 +140,18 @@ jobs:
             -s build_type=${{ inputs.build-type }} \
             --build missing \
             deps/sisl
+        conan remove -f sisl
       if: ${{ inputs.testing == 'True' }}
 
     - name: Cleanup
       run: |
-        ls -1d ~/.conan/data/* | grep -Ev '(folly|gperftools|jemalloc|prerelease_dummy|spdlog)' | xargs rm -rf
+        dirty_pkgs=$(ls -1d ~/.conan/data/*/*/*/*/build | sed 's,.*data/,,')
+        dirty_pkgs_v=$(echo "${dirty_pkgs}" | cut -d'/' -f1,2 | paste -sd',' - -)
+        echo "::info:: Caching: ${dirty_pkgs_v}"
+        dirty_pkgs_d=$(echo "${dirty_pkgs}" | cut -d'/' -f1 | paste -sd'|' - -)
+        ls -1d ~/.conan/data/* | grep -Ev "(${dirty_pkgs_d})" | xargs rm -rf
         rm -rf ~/.conan/data/*/*/*/*/build
+        rm -rf ~/.conan/data/*/*/*/*/source
       if: ${{ steps.restore-cache-sisl.outputs.cache-hit != 'true' }}
 
     - name: Save Sisl Cache
@@ -135,5 +160,5 @@ jobs:
       with:
         path: |
           ~/.conan/data
-        key: SislDeps-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}
+        key: SislDeps-${{ inputs.platform }}-${{ inputs.build-type }}-${{ inputs.malloc-impl }}-${{ inputs.prerelease }}
       if: ${{ github.event_name != 'pull_request' && steps.restore-cache-sisl.outputs.cache-hit != 'true' }}

--- a/.github/workflows/merge_conan_build.yml
+++ b/.github/workflows/merge_conan_build.yml
@@ -11,18 +11,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        platform: ["ubuntu-22.04", "ubuntu-20.04", "macos-13", "macos-12"]
         build-type: ["Debug", "Release"]
         malloc-impl: ["libc", "tcmalloc", "jemalloc"]
         prerelease: ["True", "False"]
         exclude:
+          - malloc-impl: jemalloc
+            platform: macos-13
+          - malloc-impl: jemalloc
+            platform: macos-12
           - build-type: Debug
             malloc-impl: tcmalloc
           - build-type: Debug
             malloc-impl: jemalloc
           - build-type: Release
             malloc-impl: libc
+          - prerelease: "True"
+            platform: macos-13
+          - prerelease: "True"
+            platform: macos-12
+          - prerelease: "True"
+            platform: ubuntu-20.04
     uses: ./.github/workflows/build_dependencies.yml
     with:
+      platform: ${{ matrix.platform }}
       branch: ${{ github.ref }}
       build-type: ${{ matrix.build-type }}
       malloc-impl: ${{ matrix.malloc-impl }}

--- a/.github/workflows/merge_conan_build.yml
+++ b/.github/workflows/merge_conan_build.yml
@@ -1,6 +1,7 @@
 name: Sisl Merge Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - stable/v8.x

--- a/.github/workflows/merge_conan_build.yml
+++ b/.github/workflows/merge_conan_build.yml
@@ -1,4 +1,4 @@
-name: Sisl Merge Build
+name: Sisl Build
 
 on:
   workflow_dispatch:
@@ -12,27 +12,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ubuntu-22.04", "ubuntu-20.04", "macos-13", "macos-12"]
+        platform: ["ubuntu-22.04", "ubuntu-20.04", "macos-13"]
         build-type: ["Debug", "Release"]
         malloc-impl: ["libc", "tcmalloc", "jemalloc"]
         prerelease: ["True", "False"]
         exclude:
-          - malloc-impl: jemalloc
-            platform: macos-13
-          - malloc-impl: jemalloc
-            platform: macos-12
           - build-type: Debug
-            malloc-impl: tcmalloc
-          - build-type: Debug
-            malloc-impl: jemalloc
-          - build-type: Release
-            malloc-impl: libc
-          - prerelease: "True"
-            platform: macos-13
-          - prerelease: "True"
-            platform: macos-12
-          - prerelease: "True"
             platform: ubuntu-20.04
+          - malloc-impl: tcmalloc
+            platform: ubuntu-20.04
+          - malloc-impl: jemalloc
+            platform: ubuntu-20.04
+          - build-type: Debug
+            platform: macos-13
+          - malloc-impl: libc
+            prerelease: "False"
+          - malloc-impl: tcmalloc
+            platform: macos-13
+          - malloc-impl: jemalloc
+            platform: macos-13
+          - malloc-impl: jemalloc
+            build-type: Debug
+          - malloc-impl: jemalloc
+            prerelease: "False"
+          - malloc-impl: libc
+            build-type: Release
+            platform: ubuntu-22.04
+          - prerelease: "False"
+            build-type: Debug
     uses: ./.github/workflows/build_dependencies.yml
     with:
       platform: ${{ matrix.platform }}

--- a/.github/workflows/pr_conan_build.yml
+++ b/.github/workflows/pr_conan_build.yml
@@ -11,18 +11,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        platform: ["ubuntu-22.04", "ubuntu-20.04", "macos-13"]
         build-type: ["Debug", "Release"]
         malloc-impl: ["libc", "tcmalloc", "jemalloc"]
         prerelease: ["True", "False"]
         exclude:
+          - platform: macos-13
+            malloc-impl: jemalloc
+          - build-type: Release
+            platform: ubuntu-20.04
+          - build-type: Release
+            platform: macos-13
           - build-type: Debug
             malloc-impl: tcmalloc
           - build-type: Debug
             malloc-impl: jemalloc
           - build-type: Release
             malloc-impl: libc
+          - prerelease: "True"
+            platform: macos-13
+          - prerelease: "True"
+            platform: macos-12
+          - prerelease: "True"
+            platform: ubuntu-20.04
     uses: ./.github/workflows/build_dependencies.yml
     with:
+      platform: ${{ matrix.platform }}
       branch: ${{ github.ref }}
       build-type: ${{ matrix.build-type }}
       malloc-impl: ${{ matrix.malloc-impl }}

--- a/.github/workflows/pr_conan_build.yml
+++ b/.github/workflows/pr_conan_build.yml
@@ -16,24 +16,29 @@ jobs:
         malloc-impl: ["libc", "tcmalloc", "jemalloc"]
         prerelease: ["True", "False"]
         exclude:
-          - platform: macos-13
-            malloc-impl: jemalloc
-          - build-type: Release
-            platform: ubuntu-20.04
-          - build-type: Release
-            platform: macos-13
           - build-type: Debug
-            malloc-impl: tcmalloc
-          - build-type: Debug
-            malloc-impl: jemalloc
-          - build-type: Release
-            malloc-impl: libc
-          - prerelease: "True"
-            platform: macos-13
-          - prerelease: "True"
-            platform: macos-12
-          - prerelease: "True"
             platform: ubuntu-20.04
+          - malloc-impl: tcmalloc
+            platform: ubuntu-20.04
+          - malloc-impl: jemalloc
+            platform: ubuntu-20.04
+          - build-type: Debug
+            platform: macos-13
+          - malloc-impl: libc
+            prerelease: "False"
+          - malloc-impl: tcmalloc
+            platform: macos-13
+          - malloc-impl: jemalloc
+            platform: macos-13
+          - malloc-impl: jemalloc
+            build-type: Debug
+          - malloc-impl: jemalloc
+            prerelease: "False"
+          - malloc-impl: libc
+            build-type: Release
+            platform: ubuntu-22.04
+          - prerelease: "False"
+            build-type: Debug
     uses: ./.github/workflows/build_dependencies.yml
     with:
       platform: ${{ matrix.platform }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,32 +49,30 @@ if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 endif()
 
-find_package(benchmark REQUIRED)
-find_package(Boost REQUIRED)
-find_package(cpr REQUIRED)
-find_package(cxxopts REQUIRED)
-find_package(GTest REQUIRED)
+find_package(benchmark QUIET REQUIRED)
+find_package(Boost QUIET REQUIRED)
+find_package(cpr QUIET REQUIRED)
+find_package(cxxopts QUIET REQUIRED)
+find_package(GTest QUIET REQUIRED)
 if (${MALLOC_IMPL} STREQUAL "tcmalloc")
-    find_package(gperftools REQUIRED)
+  find_package(gperftools QUIET REQUIRED)
 endif()
 
 if (${MALLOC_IMPL} STREQUAL "jemalloc")
-    find_package(jemalloc REQUIRED)
+  find_package(jemalloc QUIET REQUIRED)
 endif()
 
-find_package(jwt-cpp REQUIRED)
-find_package(nlohmann_json REQUIRED)
+find_package(jwt-cpp QUIET REQUIRED)
+find_package(nlohmann_json QUIET REQUIRED)
 find_package(prerelease_dummy QUIET)
-find_package(prometheus-cpp REQUIRED)
-find_package(zmarok-semver REQUIRED)
-find_package(spdlog REQUIRED)
-find_package(Threads REQUIRED)
+find_package(prometheus-cpp QUIET REQUIRED)
+find_package(zmarok-semver QUIET REQUIRED)
+find_package(spdlog QUIET REQUIRED)
+find_package(Threads QUIET REQUIRED)
 
 # Linux Specific dependencies
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Linux)
-    find_package(folly REQUIRED)
-    find_package(userspace-rcu REQUIRED)
-endif()
+find_package(folly QUIET)
+find_package(userspace-rcu QUIET)
 
 list (APPEND COMMON_DEPS
     Boost::headers
@@ -83,10 +81,8 @@ list (APPEND COMMON_DEPS
     prometheus-cpp::prometheus-cpp
     spdlog::spdlog
   )
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Linux)
-    list (APPEND COMMON_DEPS
-        userspace-rcu::userspace-rcu
-    )
+if(${userspace-rcu_FOUND})
+    list (APPEND COMMON_DEPS userspace-rcu::userspace-rcu)
 endif()
 
 if (${prerelease_dummy_FOUND})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required (VERSION 3.11)
 
-add_subdirectory (grpc)
 add_subdirectory (logging)
 add_subdirectory (options)
 add_subdirectory (version)
@@ -16,7 +15,13 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
         $<TARGET_OBJECTS:sisl_auth_manager>
       )
 endif()
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Linux)
+if(${userspace-rcu_FOUND})
+    add_subdirectory (grpc)
+    list(APPEND POSIX_LIBRARIES
+            $<TARGET_OBJECTS:sisl_grpc>
+    )
+endif()
+if(${folly_FOUND})
     add_subdirectory (cache)
     add_subdirectory (fds)
     add_subdirectory (file_watcher)
@@ -40,7 +45,6 @@ endif()
 
 add_library(sisl
             ${POSIX_LIBRARIES}
-            $<TARGET_OBJECTS:sisl_grpc>
             $<TARGET_OBJECTS:sisl_logging>
             $<TARGET_OBJECTS:sisl_options>
             $<TARGET_OBJECTS:sisl_version>

--- a/src/auth_manager/CMakeLists.txt
+++ b/src/auth_manager/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.11)
 
-find_package(flatbuffers REQUIRED)
-find_package(Pistache REQUIRED)
+find_package(flatbuffers QUIET REQUIRED)
+find_package(Pistache QUIET REQUIRED)
 
 if(NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR})

--- a/src/flip/CMakeLists.txt
+++ b/src/flip/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-find_package(gRPC REQUIRED)
+find_package(gRPC QUIET REQUIRED)
 
 add_subdirectory (proto)
 

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.11)
 
-find_package(flatbuffers REQUIRED)
-find_package(gRPC REQUIRED)
+find_package(flatbuffers QUIET REQUIRED)
+find_package(gRPC QUIET REQUIRED)
 
 include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/../auth_manager)
 
@@ -19,4 +19,6 @@ target_link_libraries(sisl_grpc
     ${COMMON_DEPS}
   )
 
-add_subdirectory(tests)
+if(${Pistache_FOUND})
+  add_subdirectory(tests)
+endif()

--- a/src/grpc/tests/CMakeLists.txt
+++ b/src/grpc/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.11)
 
-find_package(GTest REQUIRED)
-find_package(Pistache REQUIRED)
+find_package(GTest QUIET REQUIRED)
+find_package(Pistache QUIET REQUIRED)
 
 add_subdirectory(proto)
 

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.11)
 
-find_package(flatbuffers REQUIRED)
+find_package(flatbuffers QUIET REQUIRED)
 
 add_library(sisl_settings OBJECT)
 target_sources(sisl_settings PRIVATE

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.11)
 project(test_package)
 
+set(CMAKE_CXX_STANDARD 20)
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(sisl CONFIG REQUIRED)
+find_package(sisl CONFIG QUIET REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp example_decl.cpp)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -9,7 +9,7 @@ class TestPackageConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure()
+        cmake.configure(defs={'CONAN_CMAKE_SILENT_OUTPUT': 'ON'})
         cmake.build()
 
     def test(self):

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -22,24 +22,18 @@ int main(int argc, char** argv) {
     LOGERROR("Error");
     LOGCRITICAL("Critical");
 
-    auto thread = std::jthread([](std::stop_token stoken) {
-        example_decl();
-        while (!stoken.stop_requested()) {
-            LOGWARNMOD(my_module, "Sleeping...");
-            std::this_thread::sleep_for(1500ms);
-        }
-        LOGINFOMOD(my_module, "Waking...");
+    auto thread = std::thread([]() {
+        LOGWARNMOD(my_module, "Sleeping...");
         std::this_thread::sleep_for(1500ms);
     });
     sisl::name_thread(thread, "example_thread");
     std::this_thread::sleep_for(300ms);
-    auto stop_source = thread.get_stop_source();
 
     auto custom_logger =
         sisl::logging::CreateCustomLogger("test_package", "_custom", false /*stdout*/, true /*stderr*/);
     LOGINFOMOD_USING_LOGGER(my_module, custom_logger, "hello world");
     DEBUG_ASSERT(true, "Always True");
-    RELEASE_ASSERT(stop_source.request_stop(), "Should be!");
+    thread.join();
 
     return 0;
 }


### PR DESCRIPTION
Expand build matrix to include macOS-13 (CLang-14) and Ubuntu 20.04 (gcc-9)
Still to come: Sanitizer and CodeCoverage

note: Current build checks do not include these new jobs so will never pass below. Need to update requirements for master pr after this is merged.