### PR TITLE
Add semantics to move a blob.

### DIFF
--- a/include/sisl/fds/buffer.hpp
+++ b/include/sisl/fds/buffer.hpp
@@ -33,11 +33,8 @@
 
 namespace sisl {
 struct blob {
-    uint8_t* bytes;
-    uint32_t size;
-
-    blob() : blob{nullptr, 0} {}
-    blob(uint8_t* const b, const uint32_t s) : bytes{b}, size{s} {}
+    uint8_t* bytes{nullptr};
+    uint32_t size{0ul};
 };
 
 using sg_iovs_t = folly::small_vector< iovec, 4 >;
@@ -248,9 +245,13 @@ struct io_blob : public blob {
         buf_alloc(sz, align_size, tag);
     }
     io_blob(uint8_t* const bytes, const uint32_t size, const bool is_aligned) :
-            blob(bytes, size),
-            aligned{is_aligned} {}
+            blob{bytes, size}, aligned{is_aligned} {}
     ~io_blob() = default;
+
+    io_blob(io_blob const& rhs) = default;
+    io_blob& operator=(io_blob const& rhs) = default;
+    io_blob(io_blob&& rhs) = default;
+    io_blob& operator=(io_blob&& rhs) = default;
 
     void buf_alloc(const size_t sz, const uint32_t align_size = 512, const buftag tag = buftag::common) {
         aligned = (align_size != 0);
@@ -302,11 +303,15 @@ struct io_blob : public blob {
  */
 struct byte_array_impl : public io_blob {
     byte_array_impl(const uint32_t sz, const uint32_t alignment = 0, const buftag tag = buftag::common) :
-            io_blob(sz, alignment, tag),
-            m_tag{tag} {}
+            io_blob(sz, alignment, tag), m_tag{tag} {}
     byte_array_impl(uint8_t* const bytes, const uint32_t size, const bool is_aligned) :
             io_blob(bytes, size, is_aligned) {}
     ~byte_array_impl() { io_blob::buf_free(m_tag); }
+
+    byte_array_impl(byte_array_impl const& rhs) = default;
+    byte_array_impl& operator=(byte_array_impl const& rhs) = default;
+    byte_array_impl(byte_array_impl&& rhs) = default;
+    byte_array_impl& operator=(byte_array_impl&& rhs) = default;
 
     buftag m_tag;
 };

--- a/src/cache/tests/test_range_cache.cpp
+++ b/src/cache/tests/test_range_cache.cpp
@@ -73,7 +73,7 @@ protected:
 
     void write(const uint32_t chunk_num, const uint32_t start_blk, const uint32_t end_blk) {
         uint32_t size = (end_blk - start_blk + 1) * g_blk_size;
-        sisl::io_blob b{uintptr_cast(generate_data(size)), size, false};
+        sisl::io_blob b{static_cast< std::byte* >(generate_data(size)), size, false};
         file_write(chunk_num, start_blk, b);
         m_cache->insert(chunk_num, start_blk, end_blk - start_blk + 1, std::move(b));
     }

--- a/src/cache/tests/test_range_hashmap.cpp
+++ b/src/cache/tests/test_range_hashmap.cpp
@@ -60,7 +60,7 @@ protected:
 
         for (const auto& [key, val] : entries) {
             ASSERT_EQ(key.m_base_key, 1u) << "Expected base key is standard value 1";
-            uint8_t* got_bytes = val.bytes();
+            auto got_bytes = val.bytes();
             for (auto o{key.m_nth}; o < key.m_nth + key.m_count; ++o) {
                 auto it = m_shadow_map.find(o);
                 ASSERT_EQ(m_inserted_slots.is_bits_set(o, 1), true) << "Found a key " << o << " which was not inserted";
@@ -87,7 +87,7 @@ protected:
 
     sisl::io_blob create_data(const uint32_t start, const uint32_t end) {
         auto blob = sisl::io_blob{per_val_size * (end - start + 1), 0};
-        uint8_t* bytes = blob.bytes;
+        auto bytes = blob.bytes;
 
         for (auto i = start; i <= end; ++i) {
             auto arr = (std::array< uint32_t, per_val_size / sizeof(uint32_t) >*)bytes;
@@ -97,7 +97,7 @@ protected:
         return blob;
     }
 
-    void compare_data(const uint32_t offset, const uint8_t* l_bytes, const uint8_t* r_bytes) const {
+    void compare_data(const uint32_t offset, const std::byte* l_bytes, const std::byte* r_bytes) const {
         const auto l_arr = (std::array< uint32_t, per_val_size / sizeof(uint32_t) >*)l_bytes;
         const auto r_arr = (std::array< uint32_t, per_val_size / sizeof(uint32_t) >*)r_bytes;
 

--- a/src/fds/buffer.cpp
+++ b/src/fds/buffer.cpp
@@ -18,24 +18,24 @@
 #include "sisl/fds/buffer.hpp"
 
 namespace sisl {
-uint8_t* AlignedAllocatorImpl::aligned_alloc(const size_t align, const size_t sz, const sisl::buftag tag) {
-    auto* buf{static_cast< uint8_t* >(std::aligned_alloc(align, sisl::round_up(sz, align)))};
+std::byte* AlignedAllocatorImpl::aligned_alloc(const size_t align, const size_t sz, const sisl::buftag tag) {
+    auto* buf{static_cast< std::byte* >(std::aligned_alloc(align, sisl::round_up(sz, align)))};
     AlignedAllocator::metrics().increment(tag, buf_size(buf));
     return buf;
 }
 
-void AlignedAllocatorImpl::aligned_free(uint8_t* const b, const sisl::buftag tag) {
+void AlignedAllocatorImpl::aligned_free(std::byte* const b, const sisl::buftag tag) {
     AlignedAllocator::metrics().decrement(tag, buf_size(b));
     return std::free(b);
 }
 
-uint8_t* AlignedAllocatorImpl::aligned_realloc(uint8_t* const old_buf, const size_t align, const size_t new_sz,
-                                               const size_t old_sz) {
+std::byte* AlignedAllocatorImpl::aligned_realloc(std::byte* const old_buf, const size_t align, const size_t new_sz,
+                                                 const size_t old_sz) {
     // Glibc does not have an implementation of efficient realloc and hence we are using alloc/copy method here
     const size_t old_real_size{(old_sz == 0) ? ::malloc_usable_size(static_cast< void* >(old_buf)) : old_sz};
     if (old_real_size >= new_sz) return old_buf;
 
-    uint8_t* const new_buf{this->aligned_alloc(align, sisl::round_up(new_sz, align), buftag::common)};
+    std::byte* const new_buf{this->aligned_alloc(align, sisl::round_up(new_sz, align), buftag::common)};
     std::memcpy(static_cast< void* >(new_buf), static_cast< const void* >(old_buf), old_real_size);
 
     aligned_free(old_buf, buftag::common);


### PR DESCRIPTION
We don't need to wrap a byte_array_impl (or other blob) in a shared_ptr/unique_ptr if we have move semantics since the underlying is just a pointer mostly anyways as well. The user-defined destructor will handle RAII, no need for a pointer to a pointer I think?

We can enforce ownership via the API signature, (e.g. `void put(Blob&& blob, ...` forcing the user to release ownership and making for cleaner code with less de-referencing and checking for `nullptr`.