### PR TITLE
Fix libcurl override for OSS.

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
             steps {
                 script {
                     sh(script: "sed -Ei 's, version = .*\"([[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+).*, version = \"\\1-${env.BUILD_NUMBER}\",' conanfile.py")
+                    sh(script: "sed -Ei 's,#LIBCURLFIXTOKEN.*,self.requires(\"libcurl/7.86.0\"\\,     override=True),' conanfile.py")
                     BUILD_MISSING = "--build missing"
                 }
             }

--- a/conanfile.py
+++ b/conanfile.py
@@ -84,7 +84,7 @@ class SISLConan(ConanFile):
                 self.requires("pistache/0.0.5")
         
         self.requires("fmt/8.1.1",          override=True)
-        self.requires("libcurl/7.86.0",     override=True)
+        #LIBCURLFIXTOKEN
         self.requires("libevent/2.1.12",    override=True)
         self.requires("openssl/1.1.1q",     override=True)
         self.requires("xz_utils/5.2.5",     override=True)


### PR DESCRIPTION
conan-center has moved all their packages to use `libcurl/8.x`. eBay still use some of these built against `libcurl/7.x` for internal projects. Until we refresh shared dependencies override this for builds using eBay internal builds.