### PR TITLE
include filesystem header in logging.h

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.52.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "8.6.4"
+    version = "8.6.5"
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"
     topics = ("ebay", "components", "core", "efficiency")

--- a/include/sisl/logging/logging.h
+++ b/include/sisl/logging/logging.h
@@ -31,6 +31,7 @@
 #include <string_view>
 #include <unordered_set>
 #include <vector>
+#include <filesystem>
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/control/if.hpp>


### PR DESCRIPTION

The logging.h file declares functions with return type
`std::filesystem::path`, which is declared in standard header file
<filesystem>. However, logging.h doesn't include this header file, the
sisl library user sees too many compile errors like this:

error: ‘path’ in namespace ‘std::filesystem’ does not name a type

Even when the application src file doesn't directly include logging.h
we still see this error because we might use other sisl components,
which includes this logging.h indirectly.

To relief the user application, we should include <filesystem> in
logging.h