### PR TITLE
acquire unique lock for LRU cache get operation

### DIFF
--- a/include/sisl/auth_manager/LRUCache.h
+++ b/include/sisl/auth_manager/LRUCache.h
@@ -53,7 +53,8 @@ public:
     }
 
     [[nodiscard]] const std::optional< std::reference_wrapper< value_t const > > get(const key_t& key) {
-        std::shared_lock< std::shared_mutex > l{mtx_};
+        // we need unique lock for the splice operation
+        std::unique_lock< std::shared_mutex > l{mtx_};
 
         auto it = items_map_.find(key);
         if (it == items_map_.end()) { return std::nullopt; }


### PR DESCRIPTION
The get API in LRU cache uses splice operation to move the node to the head when there is a cache hit. This requires a unique lock but we currently take a shared lock which can cause possible corruption.
Not changing the version in conanfile as 8.6.5 is not is use currently. 