### PR TITLE
Allowed size() of concurrent vector to be const

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.52.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "10.2.3"
+    version = "10.2.4"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/src/fds/tests/test_concurrent_insert_vector.cpp
+++ b/src/fds/tests/test_concurrent_insert_vector.cpp
@@ -37,8 +37,7 @@ protected:
     std::vector< std::thread > m_threads;
 
 public:
-    ConcurrentInsertVectorTest() :
-            testing::Test(), m_cvec{s_cast< size_t >(SISL_OPTIONS["num_entries"].as< uint32_t >())} {}
+    ConcurrentInsertVectorTest() : testing::Test() {}
     ConcurrentInsertVectorTest(const ConcurrentInsertVectorTest&) = delete;
     ConcurrentInsertVectorTest(ConcurrentInsertVectorTest&&) noexcept = delete;
     ConcurrentInsertVectorTest& operator=(const ConcurrentInsertVectorTest&) = delete;
@@ -68,6 +67,7 @@ protected:
         sisl::Bitset bset{SISL_OPTIONS["num_entries"].as< uint32_t >()};
         m_cvec.foreach_entry([&bset](uint32_t const& e) { bset.set_bit(e); });
         ASSERT_EQ(bset.get_next_reset_bit(0), sisl::Bitset::npos) << "Access didn't receive all entries";
+        ASSERT_EQ(m_cvec.size(), bset.get_set_count(0)) << "Size doesn't match with number of entries";
     }
 
     void validate_all_by_iteration() {
@@ -76,6 +76,7 @@ protected:
             bset.set_bit(e);
         }
         ASSERT_EQ(bset.get_next_reset_bit(0), sisl::Bitset::npos) << "Access didn't receive all entries";
+        ASSERT_EQ(m_cvec.size(), bset.get_set_count(0)) << "Size doesn't match with number of entries";
     }
 };
 


### PR DESCRIPTION
This is needed to be able to put in a container/methods which calculate size() with const. Apart from that we also made the gather to be done only if vector is not 0 size. Otherwise at() call returns an exception inside the iterator.