### PR TITLE
Move logging definitions to source locale.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -18,7 +18,6 @@ AlignOperands:   false
 AlignTrailingComments: true
 AllowShortBlocksOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: true
-AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
 # AllowShortFunctionsOnASingleLine: InlineOnly
 # AllowShortLoopsOnASingleLine: false

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.52.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "10.2.5"
+    version = "11.0.1"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"
@@ -170,6 +170,6 @@ class SISLConan(ConanFile):
             self.cpp_info.components["core"].exelinkflags.append("-fsanitize=undefined")
         if self.options.malloc_impl == 'jemalloc':
             self.cpp_info.components["core"].cppflags.append("-DUSE_JEMALLOC=1")
-            self.cpp_info.components["core"].requires.append("jemalloc")
+            self.cpp_info.components["core"].requires.append("jemalloc::jemalloc")
         elif self.options.malloc_impl == 'tcmalloc':
-            self.cpp_info.components["core"].requires.append("tcmalloc")
+            self.cpp_info.components["core"].requires.append("gperftools::gperftools")

--- a/conanfile.py
+++ b/conanfile.py
@@ -146,27 +146,30 @@ class SISLConan(ConanFile):
         copy(self, "settings_gen.cmake", join(self.source_folder, "cmake"), join(self.package_folder, "cmake"), keep_path=False)
 
     def package_info(self):
-        self.cpp_info.libs = ["sisl"]
-
-        if self.settings.compiler == "gcc":
-            self.cpp_info.cppflags.extend(["-fconcepts"])
+        self.cpp_info.names["cmake_find_package"] = "Sisl"
+        self.cpp_info.names["cmake_find_package_multi"] = "Sisl"
+        self.cpp_info.components["core"].libs = ["sisl"]
+        self.cpp_info.components["core"].requires = ["boost::boost", "grpc::grpc++", "flatbuffers::flatbuffers", "cxxopts::cxxopts", "spdlog::spdlog", "nlohmann_json::nlohmann_json", "breakpad::breakpad", "prometheus-cpp::prometheus-cpp", "zmarok-semver::zmarok-semver"]
+        self.cpp_info.components["flip"].libs = ["flip"]
+        self.cpp_info.components["flip"].requires = ["core"]
 
         if self.settings.os == "Linux":
-            self.cpp_info.libs.append("flip")
-            self.cpp_info.cppflags.append("-D_POSIX_C_SOURCE=200809L")
-            self.cpp_info.cppflags.append("-D_FILE_OFFSET_BITS=64")
-            self.cpp_info.cppflags.append("-D_LARGEFILE64")
-            self.cpp_info.system_libs.extend(["dl", "pthread"])
-            self.cpp_info.exelinkflags.extend(["-export-dynamic"])
+            self.cpp_info.components["core"].system_libs.extend(["dl", "pthread"])
+            self.cpp_info.components["core"].cppflags.extend([
+                "-D_POSIX_C_SOURCE=200809L",
+                "-D_FILE_OFFSET_BITS=64",
+                "-D_LARGEFILE64",
+                ])
+            self.cpp_info.components["core"].exelinkflags.append("-export-dynamic")
+            self.cpp_info.components["flip"].system_libs.append("pthread")
 
         if  self.options.sanitize:
-            self.cpp_info.sharedlinkflags.append("-fsanitize=address")
-            self.cpp_info.exelinkflags.append("-fsanitize=address")
-            self.cpp_info.sharedlinkflags.append("-fsanitize=undefined")
-            self.cpp_info.exelinkflags.append("-fsanitize=undefined")
+            self.cpp_info.components["core"].sharedlinkflags.append("-fsanitize=address")
+            self.cpp_info.components["core"].exelinkflags.append("-fsanitize=address")
+            self.cpp_info.components["core"].sharedlinkflags.append("-fsanitize=undefined")
+            self.cpp_info.components["core"].exelinkflags.append("-fsanitize=undefined")
         if self.options.malloc_impl == 'jemalloc':
-            self.cpp_info.cppflags.append("-DUSE_JEMALLOC=1")
+            self.cpp_info.components["core"].cppflags.append("-DUSE_JEMALLOC=1")
+            self.cpp_info.components["core"].requires.append("jemalloc")
         elif self.options.malloc_impl == 'tcmalloc':
-            self.cpp_info.cppflags.append("-DUSING_TCMALLOC=1")
-            self.cpp_info.libdirs += self.deps_cpp_info["gperftools"].lib_paths
-            self.cpp_info.libs += ["tcmalloc"]
+            self.cpp_info.components["core"].requires.append("tcmalloc")

--- a/include/sisl/logging/logging.h
+++ b/include/sisl/logging/logging.h
@@ -245,7 +245,7 @@ constexpr const char* file_name(const char* const str) { return str_slant(str) ?
 #define _ABORT_OR_DUMP(is_log_assert)                                                                                  \
     assert(0);                                                                                                         \
     if (is_log_assert) {                                                                                               \
-        if (sisl::logging::is_crash_handler_installed()) { raise(SIGUSR3); }                    \
+        if (sisl::logging::is_crash_handler_installed()) { raise(SIGUSR3); }                                           \
     } else {                                                                                                           \
         abort();                                                                                                       \
     }
@@ -266,7 +266,7 @@ constexpr const char* file_name(const char* const str) { return str_slant(str) ?
  * LOGMSG_ASSERT:   If condition is not met: Logs the message with stack trace, aborts in debug build only.
  * DEBUG_ASSERT:    No-op in release build, for debug build, if condition is not met, logs the message and aborts
  */
-//#if __cplusplus > 201703L
+// #if __cplusplus > 201703L
 #if 0
 #define _GENERIC_ASSERT(is_log_assert, cond, formatter, msg, ...)                                                      \
     [[unlikely]] if (!(cond)) { _LOG_AND_ASSERT_FMT(is_log_assert, formatter, msg, ##__VA_ARGS__); }
@@ -448,9 +448,11 @@ MODLEVELDEC(_, _, base)
 #define SISL_LOGGING_DECL(...)                                                                                         \
     BOOST_PP_SEQ_FOR_EACH(MODLEVELDEC, spdlog::level::level_enum::off, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
-#define SISL_LOGGING_INIT(...)                                                                                         \
+#define SISL_LOGGING_DEF(...)                                                                                          \
     BOOST_PP_SEQ_FOR_EACH(MODLEVELDEF, spdlog::level::level_enum::info,                                                \
-                          BOOST_PP_TUPLE_TO_SEQ(BOOST_PP_VARIADIC_TO_TUPLE(__VA_ARGS__)))                              \
+                          BOOST_PP_TUPLE_TO_SEQ(BOOST_PP_VARIADIC_TO_TUPLE(__VA_ARGS__)))
+
+#define SISL_LOGGING_INIT(...)                                                                                         \
     sisl::logging::InitModules s_init_enabled_mods{                                                                    \
         BOOST_PP_SEQ_FOR_EACH(MOD_LEVEL_STRING, , BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))};
 

--- a/include/sisl/logging/logging.h
+++ b/include/sisl/logging/logging.h
@@ -36,10 +36,7 @@
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/preprocessor/stringize.hpp>
-#include <boost/preprocessor/tuple/push_front.hpp>
-#include <boost/preprocessor/tuple/to_seq.hpp>
 #include <boost/preprocessor/variadic/to_seq.hpp>
-#include <boost/preprocessor/variadic/to_tuple.hpp>
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h> // NOTE: There is an ordering dependecy on this header and fmt headers below
 #include <spdlog/fmt/bin_to_hex.h>
@@ -450,7 +447,7 @@ MODLEVELDEC(_, _, base)
 
 #define SISL_LOGGING_DEF(...)                                                                                          \
     BOOST_PP_SEQ_FOR_EACH(MODLEVELDEF, spdlog::level::level_enum::info,                                                \
-                          BOOST_PP_TUPLE_TO_SEQ(BOOST_PP_VARIADIC_TO_TUPLE(__VA_ARGS__)))
+                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
 #define SISL_LOGGING_INIT(...)                                                                                         \
     sisl::logging::InitModules s_init_enabled_mods{                                                                    \

--- a/include/sisl/logging/logging.h
+++ b/include/sisl/logging/logging.h
@@ -446,8 +446,7 @@ MODLEVELDEC(_, _, base)
     BOOST_PP_SEQ_FOR_EACH(MODLEVELDEC, spdlog::level::level_enum::off, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
 #define SISL_LOGGING_DEF(...)                                                                                          \
-    BOOST_PP_SEQ_FOR_EACH(MODLEVELDEF, spdlog::level::level_enum::info,                                                \
-                          BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
+    BOOST_PP_SEQ_FOR_EACH(MODLEVELDEF, spdlog::level::level_enum::err, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
 #define SISL_LOGGING_INIT(...)                                                                                         \
     sisl::logging::InitModules s_init_enabled_mods{                                                                    \

--- a/src/flip/lib/flip_rpc_server.cpp
+++ b/src/flip/lib/flip_rpc_server.cpp
@@ -25,6 +25,8 @@
 #include "sisl/flip/flip_rpc_server.hpp"
 #include "sisl/flip/flip.hpp"
 
+SISL_LOGGING_DEF(flip)
+
 namespace flip {
 grpc::Status FlipRPCServer::InjectFault(grpc::ServerContext*, const FlipSpec* request, FlipResponse* response) {
     LOGTRACEMOD(flip, "InjectFault request = {}", request->DebugString());

--- a/src/grpc/rpc_server.cpp
+++ b/src/grpc/rpc_server.cpp
@@ -26,6 +26,8 @@ extern "C" {
 
 #include <grpcpp/impl/codegen/service_type.h>
 
+SISL_LOGGING_DEF(grpc_server)
+
 namespace sisl {
 GrpcServer::GrpcServer(const std::string& listen_addr, uint32_t threads, const std::string& ssl_key,
                        const std::string& ssl_cert) :

--- a/src/logging/logging.cpp
+++ b/src/logging/logging.cpp
@@ -57,10 +57,7 @@ SISL_OPTION_GROUP(logging, (enab_mods,  "", "log_mods", "Module loggers to enabl
                           (version,    "V", "version", "Print the version and exist", ::cxxopts::value<bool>(), ""))
 // clang-format on
 
-// logger required define if not inited
-extern "C" {
-spdlog::level::level_enum module_level_base{spdlog::level::level_enum::info};
-}
+SISL_LOGGING_DEF(base)
 
 namespace sisl {
 namespace logging {

--- a/src/logging/logging.cpp
+++ b/src/logging/logging.cpp
@@ -251,7 +251,8 @@ static std::string setup_modules() {
             fmt::vformat_to(std::back_inserter(out_str), fmt::string_view{"{}={}, "},
                             fmt::make_format_args(mod_name, lvl_str));
         }
-    }
+    } else
+        set_module_log_level("base", spdlog::level::level_enum::info);
 
     if (SISL_OPTIONS.count("log_mods")) {
         std::regex re{"[\\s,]+"};

--- a/src/logging/test/example.cpp
+++ b/src/logging/test/example.cpp
@@ -24,6 +24,8 @@
 
 #include <sisl/logging/logging.h>
 
+SISL_LOGGING_DECL(my_module)
+SISL_LOGGING_DEF(my_module)
 SISL_LOGGING_INIT(my_module)
 
 void func() {

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -6,8 +6,8 @@ set(CMAKE_CXX_STANDARD 20)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup(TARGETS)
 
-find_package(sisl CONFIG QUIET REQUIRED)
+find_package(Sisl CONFIG QUIET REQUIRED)
 
 add_executable(${PROJECT_NAME} test_package.cpp example_decl.cpp)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
-target_link_libraries(${PROJECT_NAME} sisl::sisl)
+target_link_libraries(${PROJECT_NAME} Sisl::flip)

--- a/test_package/example_decl.cpp
+++ b/test_package/example_decl.cpp
@@ -1,6 +1,6 @@
 #include <sisl/logging/logging.h>
 
-SISL_LOGGING_DECL(my_module)
+SISL_LOGGING_DEF(my_module)
 
 void example_decl() {
   LOGINFOMOD(my_module, "Example def!");

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -2,6 +2,7 @@
 #include <sisl/options/options.h>
 #include <sisl/utility/thread_factory.hpp>
 
+SISL_LOGGING_DECL(my_module)
 SISL_LOGGING_INIT(my_module)
 
 SISL_OPTIONS_ENABLE(logging)


### PR DESCRIPTION
The only thing `LOGGING_INIT` is needed for now is to register a given module with the subsystem so it can be controlled _after_ startup (e.g. REST call), but they will all log.