### PR TITLE
Add the option to get the request as sisl::io_blob from the generic service

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.52.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "10.2.5"
+    version = "10.3.1"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"


### PR DESCRIPTION
Extent the generic rpc data to return the request buffer as `sisl::io_blob`. 