### PR TITLE
bump libcurl and openssl version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -96,7 +96,7 @@ class SISLConan(ConanFile):
         self.requires("spdlog/1.12.0")
         self.requires("zmarok-semver/1.1.0")
         self.requires("fmt/10.0.0",     override=True)
-        self.requires("libcurl/8.2.1",  override=True)
+        self.requires("libcurl/8.4.0",  override=True)
         self.requires("openssl/3.1.3",  override=True)
         self.requires("xz_utils/5.2.5", override=True)
         self.requires("zlib/1.2.13",    override=True)


### PR DESCRIPTION
<img width="1502" alt="Screenshot 2023-12-28 at 10 03 45" src="https://github.com/eBay/sisl/assets/80438902/798c5ac3-ce63-4db2-a5ca-1f97016614b5">

after this PR and https://github.com/eBay/nuraft_mesg/pull/61 are both merged , homestore repl branch merging master (https://github.com/eBay/HomeStore/pull/266) can be built with iomgr 11, which depends sisl11