### PR TITLE
Add fix for flip grpc server

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.52.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "11.0.5"
+    version = "11.0.6"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/flip/flip.hpp
+++ b/include/sisl/flip/flip.hpp
@@ -29,6 +29,11 @@
 #include <cstdlib>
 #include <string>
 #include <regex>
+#include <grpc/grpc.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
+#include <grpcpp/security/server_credentials.h>
 
 #include "proto/flip_spec.pb.h"
 #include "flip_rpc_server.hpp"
@@ -431,6 +436,9 @@ static constexpr int DELAYED_RETURN = 3;
 class Flip {
 public:
     Flip() : m_flip_enabled(false) {}
+    ~Flip() {
+        if (m_flip_server) { stop_rpc_server(); }
+    }
 
     static Flip& instance() {
         static Flip s_instance;
@@ -438,14 +446,23 @@ public:
     }
 
     void start_rpc_server() {
+        if (m_flip_server) { stop_rpc_server(); }
+
         m_flip_server = std::make_unique< FlipRPCServer >();
-        m_flip_server_thread =
-            std::unique_ptr< std::thread >(new std::thread([this]() { m_flip_server->rpc_thread(); }));
-        m_flip_server_thread->detach();
+        std::string server_address("0.0.0.0:50051");
+        grpc::ServerBuilder builder;
+        builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+        builder.RegisterService((FlipRPCServer::Service*)m_flip_server.get());
+        m_grpc_server = builder.BuildAndStart();
+        LOGINFOMOD(flip, "Flip GRPC Server listening on {}", server_address);
+        m_flip_server_thread = std::unique_ptr< std::thread >(
+            new std::thread([grpc_server = m_grpc_server.get()]() { grpc_server->Wait(); }));
     }
 
     void stop_rpc_server() {
-        m_flip_server->shutdown();
+        if (m_grpc_server) { m_grpc_server->Shutdown(); }
+        m_flip_server_thread->join();
+        m_flip_server_thread.reset();
         m_flip_server.reset();
     }
 
@@ -675,6 +692,7 @@ private:
     std::unique_ptr< FlipTimerBase > m_timer;
     std::unique_ptr< std::thread > m_flip_server_thread;
     std::unique_ptr< FlipRPCServer > m_flip_server;
+    std::unique_ptr< grpc::Server > m_grpc_server;
 };
 
 } // namespace flip

--- a/include/sisl/flip/flip_rpc_server.hpp
+++ b/include/sisl/flip/flip_rpc_server.hpp
@@ -29,12 +29,5 @@ public:
                            FlipListResponse* response) override;
     grpc::Status RemoveFault(grpc::ServerContext*, const FlipRemoveRequest* request,
                              FlipRemoveResponse* response) override;
-    void rpc_thread();
-    void shutdown() {
-        if (m_server) { m_server->Shutdown(); }
-    }
-
-private:
-    std::unique_ptr< grpc::Server > m_server;
 };
 } // namespace flip

--- a/src/flip/lib/flip_rpc_server.cpp
+++ b/src/flip/lib/flip_rpc_server.cpp
@@ -63,16 +63,4 @@ public:
     }
 };
 
-void FlipRPCServer::rpc_thread() {
-    std::string server_address("0.0.0.0:50051");
-    FlipRPCServer service;
-
-    grpc::ServerBuilder builder;
-    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-    builder.RegisterService((FlipRPCServer::Service*)&service);
-    m_server = builder.BuildAndStart();
-    LOGINFOMOD(flip, "Flip GRPC Server listening on {}", server_address);
-    m_server->Wait();
-}
-
 } // namespace flip


### PR DESCRIPTION
IndexBtree and membtree tests were timing out  in githubactions and azure cloud VM because lot of grpc threads created due to restart() in UT's. Each restart creates a flip grpc thread. Adding a stop thread function which will be called in homestore shutdown so that there is no leak and thread is terminated properly. Moving the grpc code outside of thread because we are getting ASAN heap overflow errors. Its reproducible only on local builds. No change in functionality.