### PR TITLE
Generic client blob

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,6 @@ from os.path import join
 
 required_conan_version = ">=1.60.0"
 
-
 class SISLConan(ConanFile):
     name = "sisl"
     version = "11.1.5"
@@ -61,7 +60,7 @@ class SISLConan(ConanFile):
             raise ConanInvalidConfiguration("gRPC support requires metrics option!")
 
         if self.settings.compiler in ["gcc"]:
-            self.options["pistache"].with_ssl: True
+            self.options['pistache'].with_ssl: True
         if self.options.shared:
             self.options.rm_safe("fPIC")
         if self.settings.build_type == "Debug":
@@ -70,9 +69,7 @@ class SISLConan(ConanFile):
                 raise ConanInvalidConfiguration("Sanitizer does not work with Code Coverage!")
             if self.conf.get("tools.build:skip_test", default=False):
                 if self.options.coverage or self.options.sanitize:
-                    raise ConanInvalidConfiguration(
-                        "Coverage/Sanitizer requires Testing!"
-                    )
+                    raise ConanInvalidConfiguration("Coverage/Sanitizer requires Testing!")
 
     def build_requirements(self):
         self.test_requires("gtest/1.14.0")
@@ -144,71 +141,23 @@ class SISLConan(ConanFile):
 
     def package(self):
         lib_dir = join(self.package_folder, "lib")
-        copy(
-            self,
-            "LICENSE",
-            self.source_folder,
-            join(self.package_folder, "licenses"),
-            keep_path=False,
-        )
+        copy(self, "LICENSE", self.source_folder, join(self.package_folder, "licenses"), keep_path=False)
         copy(self, "*.lib", self.build_folder, lib_dir, keep_path=False)
         copy(self, "*.a", self.build_folder, lib_dir, keep_path=False)
         copy(self, "*.so*", self.build_folder, lib_dir, keep_path=False)
         copy(self, "*.dylib*", self.build_folder, lib_dir, keep_path=False)
-        copy(
-            self,
-            "*.dll*",
-            self.build_folder,
-            join(self.package_folder, "bin"),
-            keep_path=False,
-        )
+        copy(self, "*.dll*", self.build_folder, join(self.package_folder, "bin"), keep_path=False)
         copy(self, "*.so*", self.build_folder, lib_dir, keep_path=False)
-        copy(
-            self,
-            "*.proto",
-            join(self.source_folder, "src", "flip", "proto"),
-            join(self.package_folder, "proto", "flip"),
-            keep_path=False,
-        )
-        copy(
-            self,
-            "*",
-            join(self.source_folder, "src", "flip", "client", "python"),
-            join(self.package_folder, "bindings", "flip", "python"),
-            keep_path=False,
-        )
-        copy(
-            self,
-            "*.py",
-            join(self.build_folder, "src", "flip", "proto"),
-            join(self.package_folder, "bindings", "flip", "python"),
-            keep_path=False,
-        )
+        copy(self, "*.proto", join(self.source_folder, "src", "flip", "proto"), join(self.package_folder, "proto", "flip"), keep_path=False)
+        copy(self, "*", join(self.source_folder, "src", "flip", "client", "python"), join(self.package_folder, "bindings", "flip", "python"), keep_path=False)
+        copy(self, "*.py", join(self.build_folder, "src", "flip", "proto"), join(self.package_folder, "bindings", "flip", "python"), keep_path=False)
 
-        copy(
-            self,
-            "*.h*",
-            join(self.source_folder, "include"),
-            join(self.package_folder, "include"),
-            keep_path=True,
-        )
+        copy(self, "*.h*", join(self.source_folder, "include"), join(self.package_folder, "include"), keep_path=True)
 
         gen_dir = join(self.package_folder, "include", "sisl")
         copy(self, "*.pb.h", join(self.build_folder, "src"), gen_dir, keep_path=True)
-        copy(
-            self,
-            "*security_config_generated.h",
-            join(self.build_folder, "src"),
-            gen_dir,
-            keep_path=True,
-        )
-        copy(
-            self,
-            "settings_gen.cmake",
-            join(self.source_folder, "cmake"),
-            join(self.package_folder, "cmake"),
-            keep_path=False,
-        )
+        copy(self, "*security_config_generated.h", join(self.build_folder, "src"), gen_dir, keep_path=True)
+        copy(self, "settings_gen.cmake", join(self.source_folder, "cmake"), join(self.package_folder, "cmake"), keep_path=False)
 
     def package_info(self):
         self.cpp_info.components["options"].libs = ["sisl_options"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,7 @@ from os.path import join
 
 required_conan_version = ">=1.60.0"
 
+
 class SISLConan(ConanFile):
     name = "sisl"
     version = "11.1.5"
@@ -60,7 +61,7 @@ class SISLConan(ConanFile):
             raise ConanInvalidConfiguration("gRPC support requires metrics option!")
 
         if self.settings.compiler in ["gcc"]:
-            self.options['pistache'].with_ssl: True
+            self.options["pistache"].with_ssl: True
         if self.options.shared:
             self.options.rm_safe("fPIC")
         if self.settings.build_type == "Debug":
@@ -69,7 +70,9 @@ class SISLConan(ConanFile):
                 raise ConanInvalidConfiguration("Sanitizer does not work with Code Coverage!")
             if self.conf.get("tools.build:skip_test", default=False):
                 if self.options.coverage or self.options.sanitize:
-                    raise ConanInvalidConfiguration("Coverage/Sanitizer requires Testing!")
+                    raise ConanInvalidConfiguration(
+                        "Coverage/Sanitizer requires Testing!"
+                    )
 
     def build_requirements(self):
         self.test_requires("gtest/1.14.0")
@@ -141,23 +144,71 @@ class SISLConan(ConanFile):
 
     def package(self):
         lib_dir = join(self.package_folder, "lib")
-        copy(self, "LICENSE", self.source_folder, join(self.package_folder, "licenses"), keep_path=False)
+        copy(
+            self,
+            "LICENSE",
+            self.source_folder,
+            join(self.package_folder, "licenses"),
+            keep_path=False,
+        )
         copy(self, "*.lib", self.build_folder, lib_dir, keep_path=False)
         copy(self, "*.a", self.build_folder, lib_dir, keep_path=False)
         copy(self, "*.so*", self.build_folder, lib_dir, keep_path=False)
         copy(self, "*.dylib*", self.build_folder, lib_dir, keep_path=False)
-        copy(self, "*.dll*", self.build_folder, join(self.package_folder, "bin"), keep_path=False)
+        copy(
+            self,
+            "*.dll*",
+            self.build_folder,
+            join(self.package_folder, "bin"),
+            keep_path=False,
+        )
         copy(self, "*.so*", self.build_folder, lib_dir, keep_path=False)
-        copy(self, "*.proto", join(self.source_folder, "src", "flip", "proto"), join(self.package_folder, "proto", "flip"), keep_path=False)
-        copy(self, "*", join(self.source_folder, "src", "flip", "client", "python"), join(self.package_folder, "bindings", "flip", "python"), keep_path=False)
-        copy(self, "*.py", join(self.build_folder, "src", "flip", "proto"), join(self.package_folder, "bindings", "flip", "python"), keep_path=False)
+        copy(
+            self,
+            "*.proto",
+            join(self.source_folder, "src", "flip", "proto"),
+            join(self.package_folder, "proto", "flip"),
+            keep_path=False,
+        )
+        copy(
+            self,
+            "*",
+            join(self.source_folder, "src", "flip", "client", "python"),
+            join(self.package_folder, "bindings", "flip", "python"),
+            keep_path=False,
+        )
+        copy(
+            self,
+            "*.py",
+            join(self.build_folder, "src", "flip", "proto"),
+            join(self.package_folder, "bindings", "flip", "python"),
+            keep_path=False,
+        )
 
-        copy(self, "*.h*", join(self.source_folder, "include"), join(self.package_folder, "include"), keep_path=True)
+        copy(
+            self,
+            "*.h*",
+            join(self.source_folder, "include"),
+            join(self.package_folder, "include"),
+            keep_path=True,
+        )
 
         gen_dir = join(self.package_folder, "include", "sisl")
         copy(self, "*.pb.h", join(self.build_folder, "src"), gen_dir, keep_path=True)
-        copy(self, "*security_config_generated.h", join(self.build_folder, "src"), gen_dir, keep_path=True)
-        copy(self, "settings_gen.cmake", join(self.source_folder, "cmake"), join(self.package_folder, "cmake"), keep_path=False)
+        copy(
+            self,
+            "*security_config_generated.h",
+            join(self.build_folder, "src"),
+            gen_dir,
+            keep_path=True,
+        )
+        copy(
+            self,
+            "settings_gen.cmake",
+            join(self.source_folder, "cmake"),
+            join(self.package_folder, "cmake"),
+            keep_path=False,
+        )
 
     def package_info(self):
         self.cpp_info.components["options"].libs = ["sisl_options"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "11.1.5"
+    version = "11.1.6"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/grpc/generic_service.hpp
+++ b/include/sisl/grpc/generic_service.hpp
@@ -17,6 +17,7 @@
 #include <grpcpp/generic/async_generic_service.h>
 #include "sisl/fds/buffer.hpp"
 #include "rpc_call.hpp"
+#include "utils.hpp"
 
 namespace sisl {
 
@@ -60,6 +61,7 @@ public:
     const grpc::ByteBuffer& request() const { return m_request; }
     sisl::io_blob& request_blob() {
         if (m_request_blob.cbytes() == nullptr) {
+
             grpc::Slice slice;
             auto status = m_request.TrySingleSlice(&slice);
             if (status.ok()) {
@@ -71,8 +73,7 @@ public:
                 if (status = m_request.DumpToSingleSlice(&slice); status.ok()) {
                     m_request_blob.buf_alloc(slice.size());
                     m_request_blob_allocated = true;
-                    std::memcpy(voidptr_cast(m_request_blob.bytes()), c_voidptr_cast(slice.begin()),
-                                slice.size());
+                    std::memcpy(voidptr_cast(m_request_blob.bytes()), c_voidptr_cast(slice.begin()), slice.size());
                 }
             }
         }

--- a/include/sisl/grpc/generic_service.hpp
+++ b/include/sisl/grpc/generic_service.hpp
@@ -17,7 +17,6 @@
 #include <grpcpp/generic/async_generic_service.h>
 #include "sisl/fds/buffer.hpp"
 #include "rpc_call.hpp"
-#include "utils.hpp"
 
 namespace sisl {
 
@@ -29,8 +28,7 @@ namespace sisl {
 
 class GenericRpcStaticInfo : public RpcStaticInfoBase {
 public:
-    GenericRpcStaticInfo(GrpcServer* server, grpc::AsyncGenericService* service) :
-            m_server{server}, m_generic_service{service} {}
+    GenericRpcStaticInfo(GrpcServer* server, grpc::AsyncGenericService* service);
 
     GrpcServer* m_server;
     grpc::AsyncGenericService* m_generic_service;
@@ -44,58 +42,31 @@ using generic_rpc_ctx_ptr = std::unique_ptr< GenericRpcContextBase >;
 
 class GenericRpcData : public RpcDataAbstract, sisl::ObjLifeCounter< GenericRpcData > {
 public:
-    static RpcDataAbstract* make(GenericRpcStaticInfo* rpc_info, size_t queue_idx) {
-        return new GenericRpcData(rpc_info, queue_idx);
-    }
+    static RpcDataAbstract* make(GenericRpcStaticInfo* rpc_info, size_t queue_idx);
 
-    RpcDataAbstract* create_new() override { return new GenericRpcData(m_rpc_info, m_queue_idx); }
-    void set_status(grpc::Status& status) { m_retstatus = status; }
+    RpcDataAbstract* create_new() override;
+    void set_status(grpc::Status& status);
 
-    ~GenericRpcData() override {
-        if (m_request_blob_allocated) { m_request_blob.buf_free(); }
-    }
+    ~GenericRpcData() override;
 
     // There is only one generic static rpc data for all rpcs.
-    size_t get_rpc_idx() const override { return 0; }
+    size_t get_rpc_idx() const override;
 
-    const grpc::ByteBuffer& request() const { return m_request; }
-    sisl::io_blob& request_blob() {
-        if (m_request_blob.cbytes() == nullptr) {
+    const grpc::ByteBuffer& request() const;
+    sisl::io_blob& request_blob();
 
-            grpc::Slice slice;
-            auto status = m_request.TrySingleSlice(&slice);
-            if (status.ok()) {
-                m_request_blob.set_bytes(slice.begin());
-                m_request_blob.set_size(slice.size());
-            } else if (status.error_code() == grpc::StatusCode::FAILED_PRECONDITION) {
-                // If the ByteBuffer is not made up of single slice, TrySingleSlice() will fail.
-                // DumpSingleSlice() should work in those cases but will incur a copy.
-                if (status = m_request.DumpToSingleSlice(&slice); status.ok()) {
-                    m_request_blob.buf_alloc(slice.size());
-                    m_request_blob_allocated = true;
-                    std::memcpy(voidptr_cast(m_request_blob.bytes()), c_voidptr_cast(slice.begin()), slice.size());
-                }
-            }
-        }
-        return m_request_blob;
-    }
+    grpc::ByteBuffer& response();
 
-    grpc::ByteBuffer& response() { return m_response; }
+    void enqueue_call_request(::grpc::ServerCompletionQueue& cq) override;
 
-    void enqueue_call_request(::grpc::ServerCompletionQueue& cq) override {
-        m_rpc_info->m_generic_service->RequestCall(&m_ctx, &m_stream, &cq, &cq,
-                                                   static_cast< void* >(m_request_received_tag.ref()));
-    }
+    void send_response();
 
-    void send_response() { m_stream.Write(m_response, static_cast< void* >(m_buf_write_tag.ref())); }
+    void set_context(generic_rpc_ctx_ptr ctx);
+    GenericRpcContextBase* get_context();
 
-    void set_context(generic_rpc_ctx_ptr ctx) { m_rpc_context = std::move(ctx); }
-    GenericRpcContextBase* get_context() { return m_rpc_context.get(); }
+    void set_comp_cb(generic_rpc_completed_cb_t const& comp_cb);
 
-    void set_comp_cb(generic_rpc_completed_cb_t const& comp_cb) { m_comp_cb = comp_cb; }
-
-    GenericRpcData(GenericRpcStaticInfo* rpc_info, size_t queue_idx) :
-            RpcDataAbstract{queue_idx}, m_rpc_info{rpc_info}, m_stream(&m_ctx) {}
+    GenericRpcData(GenericRpcStaticInfo* rpc_info, size_t queue_idx);
 
 private:
     GenericRpcStaticInfo* m_rpc_info;
@@ -112,54 +83,18 @@ private:
     generic_rpc_completed_cb_t m_comp_cb{nullptr};
 
 private:
-    bool do_authorization() {
-        m_retstatus = RPCHelper::do_authorization(m_rpc_info->m_server, &m_ctx);
-        return m_retstatus.error_code() == grpc::StatusCode::OK;
-    }
+    bool do_authorization();
 
-    RpcDataAbstract* on_request_received(bool ok) {
-        bool in_shutdown = RPCHelper::has_server_shutdown(m_rpc_info->m_server);
-
-        if (ok) {
-            if (!do_authorization()) {
-                m_stream.Finish(m_retstatus, static_cast< void* >(m_request_completed_tag.ref()));
-            } else {
-                m_stream.Read(&m_request, static_cast< void* >(m_buf_read_tag.ref()));
-            }
-        }
-
-        return in_shutdown ? nullptr : create_new();
-    }
-
-    RpcDataAbstract* on_buf_read(bool) {
-        auto this_rpc_data = boost::intrusive_ptr< GenericRpcData >{this};
-        // take a ref before the handler cb is called.
-        // unref is called in send_response which is handled by us (in case of sync calls)
-        // or by the handler (for async calls)
-        ref();
-        if (RPCHelper::run_generic_handler_cb(m_rpc_info->m_server, m_ctx.method(), this_rpc_data)) { send_response(); }
-        return nullptr;
-    }
-
-    RpcDataAbstract* on_buf_write(bool) {
-        m_stream.Finish(m_retstatus, static_cast< void* >(m_request_completed_tag.ref()));
-        unref();
-        return nullptr;
-    }
-
-    RpcDataAbstract* on_request_completed(bool) {
-        auto this_rpc_data = boost::intrusive_ptr< GenericRpcData >{this};
-        if (m_comp_cb) { m_comp_cb(this_rpc_data); }
-        return nullptr;
-    }
+    RpcDataAbstract* on_request_received(bool ok);
+    RpcDataAbstract* on_buf_read(bool);
+    RpcDataAbstract* on_buf_write(bool);
+    RpcDataAbstract* on_request_completed(bool);
 
     struct RpcTagImpl : public RpcTag {
         using callback_type = RpcDataAbstract* (GenericRpcData::*)(bool);
-        RpcTagImpl(GenericRpcData* rpc, callback_type cb) : RpcTag{rpc}, m_callback{cb} {}
+        RpcTagImpl(GenericRpcData* rpc, callback_type cb);
 
-        RpcDataAbstract* do_process(bool ok) override {
-            return (static_cast< GenericRpcData* >(m_rpc_data)->*m_callback)(ok);
-        }
+        RpcDataAbstract* do_process(bool ok) override;
 
         callback_type m_callback;
     };

--- a/include/sisl/grpc/rpc_client.hpp
+++ b/include/sisl/grpc/rpc_client.hpp
@@ -175,6 +175,7 @@ public:
     ~GenericClientResponse();
 
     io_blob& response_blob();
+    grpc::ByteBuffer response_buf();
 
 private:
     grpc::ByteBuffer m_response_buf;

--- a/src/grpc/CMakeLists.txt
+++ b/src/grpc/CMakeLists.txt
@@ -4,8 +4,9 @@ include_directories(BEFORE ${CMAKE_CURRENT_BINARY_DIR}/../auth_manager)
 
 add_library(sisl_grpc)
 target_sources(sisl_grpc PRIVATE
-  rpc_server.cpp
-  rpc_client.cpp
+    rpc_server.cpp
+    rpc_client.cpp
+    generic_service.cpp
   )
 target_link_libraries(sisl_grpc PUBLIC
   sisl_buffer

--- a/src/grpc/generic_service.cpp
+++ b/src/grpc/generic_service.cpp
@@ -1,0 +1,118 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+
+#include "sisl/grpc/generic_service.hpp"
+#include "utils.hpp"
+
+namespace sisl {
+
+GenericRpcStaticInfo::GenericRpcStaticInfo(GrpcServer* server, grpc::AsyncGenericService* service) :
+        m_server{server}, m_generic_service{service} {}
+
+RpcDataAbstract* GenericRpcData::make(GenericRpcStaticInfo* rpc_info, size_t queue_idx) {
+    return new GenericRpcData(rpc_info, queue_idx);
+}
+
+RpcDataAbstract* GenericRpcData::create_new() { return new GenericRpcData(m_rpc_info, m_queue_idx); }
+
+void GenericRpcData::set_status(grpc::Status& status) { m_retstatus = status; }
+
+GenericRpcData::~GenericRpcData() {
+    if (m_request_blob_allocated) { m_request_blob.buf_free(); }
+}
+
+size_t GenericRpcData::get_rpc_idx() const { return 0; }
+
+const grpc::ByteBuffer& GenericRpcData::request() const { return m_request; }
+
+sisl::io_blob& GenericRpcData::request_blob() {
+    if (m_request_blob.cbytes() == nullptr) {
+        if (auto status = try_deserialize_from_byte_buffer(m_request, m_request_blob);
+            status.error_code() == grpc::StatusCode::FAILED_PRECONDITION) {
+            if (status = deserialize_from_byte_buffer(m_request, m_request_blob); status.ok()) {
+                m_request_blob_allocated = true;
+            }
+        }
+    }
+    return m_request_blob;
+}
+
+grpc::ByteBuffer& GenericRpcData::response() { return m_response; }
+
+void GenericRpcData::enqueue_call_request(::grpc::ServerCompletionQueue& cq) {
+    m_rpc_info->m_generic_service->RequestCall(&m_ctx, &m_stream, &cq, &cq,
+                                               static_cast< void* >(m_request_received_tag.ref()));
+}
+
+void GenericRpcData::send_response() { m_stream.Write(m_response, static_cast< void* >(m_buf_write_tag.ref())); }
+
+void GenericRpcData::set_context(generic_rpc_ctx_ptr ctx) { m_rpc_context = std::move(ctx); }
+
+GenericRpcContextBase* GenericRpcData::get_context() { return m_rpc_context.get(); }
+
+void GenericRpcData::set_comp_cb(generic_rpc_completed_cb_t const& comp_cb) { m_comp_cb = comp_cb; }
+
+GenericRpcData::GenericRpcData(GenericRpcStaticInfo* rpc_info, size_t queue_idx) :
+        RpcDataAbstract{queue_idx}, m_rpc_info{rpc_info}, m_stream(&m_ctx) {}
+
+bool GenericRpcData::do_authorization() {
+    m_retstatus = RPCHelper::do_authorization(m_rpc_info->m_server, &m_ctx);
+    return m_retstatus.error_code() == grpc::StatusCode::OK;
+}
+
+RpcDataAbstract* GenericRpcData::on_request_received(bool ok) {
+    bool in_shutdown = RPCHelper::has_server_shutdown(m_rpc_info->m_server);
+
+    if (ok) {
+        if (!do_authorization()) {
+            m_stream.Finish(m_retstatus, static_cast< void* >(m_request_completed_tag.ref()));
+        } else {
+            m_stream.Read(&m_request, static_cast< void* >(m_buf_read_tag.ref()));
+        }
+    }
+
+    return in_shutdown ? nullptr : create_new();
+}
+
+RpcDataAbstract* GenericRpcData::on_buf_read(bool) {
+    auto this_rpc_data = boost::intrusive_ptr< GenericRpcData >{this};
+    // take a ref before the handler cb is called.
+    // unref is called in send_response which is handled by us (in case of sync calls)
+    // or by the handler (for async calls)
+    ref();
+    if (RPCHelper::run_generic_handler_cb(m_rpc_info->m_server, m_ctx.method(), this_rpc_data)) { send_response(); }
+    return nullptr;
+}
+
+RpcDataAbstract* GenericRpcData::on_buf_write(bool) {
+    m_stream.Finish(m_retstatus, static_cast< void* >(m_request_completed_tag.ref()));
+    unref();
+    return nullptr;
+}
+
+RpcDataAbstract* GenericRpcData::on_request_completed(bool) {
+    auto this_rpc_data = boost::intrusive_ptr< GenericRpcData >{this};
+    if (m_comp_cb) { m_comp_cb(this_rpc_data); }
+    return nullptr;
+}
+
+using callback_type = RpcDataAbstract* (GenericRpcData::*)(bool);
+GenericRpcData::RpcTagImpl::RpcTagImpl(GenericRpcData* rpc, callback_type cb) : RpcTag{rpc}, m_callback{cb} {}
+
+RpcDataAbstract* GenericRpcData::RpcTagImpl::do_process(bool ok) {
+    return (static_cast< GenericRpcData* >(m_rpc_data)->*m_callback)(ok);
+}
+
+} // namespace sisl

--- a/src/grpc/generic_service.cpp
+++ b/src/grpc/generic_service.cpp
@@ -16,6 +16,8 @@
 #include "sisl/grpc/generic_service.hpp"
 #include "utils.hpp"
 
+SISL_LOGGING_DECL(grpc_server)
+
 namespace sisl {
 
 GenericRpcStaticInfo::GenericRpcStaticInfo(GrpcServer* server, grpc::AsyncGenericService* service) :
@@ -43,7 +45,13 @@ sisl::io_blob& GenericRpcData::request_blob() {
             status.error_code() == grpc::StatusCode::FAILED_PRECONDITION) {
             if (status = deserialize_from_byte_buffer(m_request, m_request_blob); status.ok()) {
                 m_request_blob_allocated = true;
+            } else {
+                LOGERRORMOD(grpc_server, "Failed to deserialize request: code: {}. msg: {}",
+                            static_cast< int >(status.error_code()), status.error_message());
             }
+        } else if (!status.ok()) {
+            LOGERRORMOD(grpc_server, "Failed to try deserialize request: code: {}. msg: {}",
+                        static_cast< int >(status.error_code()), status.error_message());
         }
     }
     return m_request_blob;

--- a/src/grpc/rpc_client.cpp
+++ b/src/grpc/rpc_client.cpp
@@ -188,17 +188,16 @@ std::unique_ptr< GrpcAsyncClient::GenericAsyncStub > GrpcAsyncClient::make_gener
 GenericClientResponse::GenericClientResponse(grpc::ByteBuffer const& buf) : m_response_buf(buf) {}
 
 GenericClientResponse::GenericClientResponse(GenericClientResponse&& other) :
-        m_response_buf(other.m_response_buf),
-        m_response_blob(other.m_response_blob),
-        m_response_blob_allocated(other.m_response_blob_allocated) {
+        m_response_blob(other.m_response_blob), m_response_blob_allocated(other.m_response_blob_allocated) {
+    m_response_buf.Swap(&(other.m_response_buf));
     other.m_response_blob.set_bytes(static_cast< uint8_t* >(nullptr));
     other.m_response_blob.set_size(0);
 }
 
 GenericClientResponse& GenericClientResponse::operator=(GenericClientResponse&& other) {
     if (m_response_blob_allocated) { m_response_blob.buf_free(); }
-    m_response_buf = other.m_response_buf;
-    m_response_blob = other.m_response_blob;
+    m_response_buf.Clear();
+    m_response_buf.Swap(&(other.m_response_buf));
     m_response_blob_allocated = other.m_response_blob_allocated;
     other.m_response_blob.set_bytes(static_cast< uint8_t* >(nullptr));
     other.m_response_blob.set_size(0);
@@ -209,6 +208,8 @@ GenericClientResponse& GenericClientResponse::operator=(GenericClientResponse&& 
 GenericClientResponse::~GenericClientResponse() {
     if (m_response_blob_allocated) { m_response_blob.buf_free(); }
 }
+
+grpc::ByteBuffer GenericClientResponse::response_buf() { return m_response_buf; }
 
 io_blob& GenericClientResponse::response_blob() {
     if (m_response_blob.cbytes() == nullptr) {

--- a/src/grpc/rpc_client.cpp
+++ b/src/grpc/rpc_client.cpp
@@ -15,6 +15,8 @@
 #include "sisl/grpc/rpc_client.hpp"
 #include "utils.hpp"
 
+SISL_LOGGING_DECL(grpc_server)
+
 namespace sisl {
 
 GrpcBaseClient::GrpcBaseClient(const std::string& server_addr, const std::string& target_domain,
@@ -217,7 +219,13 @@ io_blob& GenericClientResponse::response_blob() {
             status.error_code() == grpc::StatusCode::FAILED_PRECONDITION) {
             if (status = deserialize_from_byte_buffer(m_response_buf, m_response_blob); status.ok()) {
                 m_response_blob_allocated = true;
+            } else {
+                LOGERRORMOD(grpc_server, "Failed to deserialize response: code: {}. msg: {}",
+                            static_cast< int >(status.error_code()), status.error_message());
             }
+        } else if (!status.ok()) {
+            LOGERRORMOD(grpc_server, "Failed to try deserialize response: code: {}. msg: {}",
+                        static_cast< int >(status.error_code()), status.error_message());
         }
     }
     return m_response_blob;

--- a/src/grpc/rpc_client.cpp
+++ b/src/grpc/rpc_client.cpp
@@ -166,9 +166,10 @@ AsyncResult< grpc::ByteBuffer > GrpcAsyncClient::GenericAsyncStub::call_unary(co
     return std::move(sf);
 }
 
-AsyncResult< io_blob > GrpcAsyncClient::GenericAsyncStub::call_unary(const io_blob_list_t& request,
-                                                                     const std::string& method, uint32_t deadline) {
-    auto [p, sf] = folly::makePromiseContract< Result< io_blob > >();
+AsyncResult< client_response_ptr > GrpcAsyncClient::GenericAsyncStub::call_unary(const io_blob_list_t& request,
+                                                                                 const std::string& method,
+                                                                                 uint32_t deadline) {
+    auto [p, sf] = folly::makePromiseContract< Result< client_response_ptr > >();
     auto data = new GenericRpcDataFutureBlob(std::move(p));
     grpc::ByteBuffer cli_byte_buf;
     serialize_to_byte_buffer(request, cli_byte_buf);
@@ -184,15 +185,32 @@ std::unique_ptr< GrpcAsyncClient::GenericAsyncStub > GrpcAsyncClient::make_gener
                                                                  m_token_client);
 }
 
-GenericRpcDataFutureBlob::GenericRpcDataFutureBlob(folly::Promise< Result< io_blob > >&& promise) :
+GenericClientResponse::GenericClientResponse(const grpc::ByteBuffer& buf) : m_response_buf(buf) {}
+
+GenericClientResponse::~GenericClientResponse() {
+    if (m_response_blob_allocated) { m_response_blob.buf_free(); }
+}
+
+io_blob& GenericClientResponse::response_blob() {
+    if (m_response_blob.cbytes() == nullptr) {
+        if (auto status = try_deserialize_from_byte_buffer(m_response_buf, m_response_blob);
+            status.error_code() == grpc::StatusCode::FAILED_PRECONDITION) {
+            if (status = deserialize_from_byte_buffer(m_response_buf, m_response_blob); status.ok()) {
+                m_response_blob_allocated = true;
+            }
+        }
+    }
+    return m_response_blob;
+}
+
+GenericRpcDataFutureBlob::GenericRpcDataFutureBlob(folly::Promise< Result< client_response_ptr > >&& promise) :
         m_promise{std::move(promise)} {}
 
 void GenericRpcDataFutureBlob::handle_response([[maybe_unused]] bool ok) {
     // For unary call, ok is always true, `status_` will indicate error if there are any.
     if (this->m_status.ok()) {
-        auto cli_buf = deserialize_from_byte_buffer(this->m_reply);
-        this->m_reply.Release();
-        m_promise.setValue(std::move(cli_buf));
+        auto future_resp = std::make_unique< GenericClientResponse >(this->m_reply);
+        m_promise.setValue(std::move(future_resp));
     } else {
         m_promise.setValue(folly::makeUnexpected(this->m_status));
     }

--- a/src/grpc/rpc_server.cpp
+++ b/src/grpc/rpc_server.cpp
@@ -219,4 +219,4 @@ grpc::Status RPCHelper::do_authorization(const GrpcServer* server, const grpc::S
     return (server->is_auth_enabled()) ? server->auth_verify(srv_ctx) : grpc::Status();
 }
 
-} // namespace sisl::grpc
+} // namespace sisl

--- a/src/grpc/tests/function/echo_async_client.cpp
+++ b/src/grpc/tests/function/echo_async_client.cpp
@@ -140,12 +140,12 @@ public:
         }
     }
 
-    void validate_generic_reply(const DataMessage& req, sisl::client_response_ptr reply, ::grpc::Status const& status,
+    void validate_generic_reply(const DataMessage& req, sisl::GenericClientResponse reply, ::grpc::Status const& status,
                                 sisl::io_blob_list_t cli_buf) {
         RELEASE_ASSERT_EQ(status.ok(), true, "generic request {} failed, status {}: {}", req.m_seqno,
                           status.error_code(), status.error_message());
         DataMessage svr_msg;
-        DeserializeFromBuffer(reply->response_blob(), svr_msg);
+        DeserializeFromBuffer(reply.response_blob(), svr_msg);
         RELEASE_ASSERT_EQ(req.m_seqno, svr_msg.m_seqno);
         RELEASE_ASSERT_EQ(req.m_buf, svr_msg.m_buf);
         {

--- a/src/grpc/tests/unit/CMakeLists.txt
+++ b/src/grpc/tests/unit/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(client_test
       client_test.cpp
   )
 target_link_libraries(client_test
-    sisl
     sisl_grpc
     GTest::gmock
     ${COMMON_DEPS}

--- a/src/grpc/tests/unit/CMakeLists.txt
+++ b/src/grpc/tests/unit/CMakeLists.txt
@@ -9,3 +9,14 @@ target_link_libraries(auth_test
     GTest::gmock
   )
 add_test(NAME Auth_Test COMMAND auth_test)
+
+add_executable(client_test
+      client_test.cpp
+  )
+target_link_libraries(client_test
+    sisl
+    sisl_grpc
+    GTest::gmock
+    ${COMMON_DEPS}
+  )
+  add_test(NAME Client_Test COMMAND client_test)

--- a/src/grpc/tests/unit/auth_test.cpp
+++ b/src/grpc/tests/unit/auth_test.cpp
@@ -356,12 +356,12 @@ TEST(GenericServiceDeathTest, basic_test) {
     auto g_grpc_server = GrpcServer::make("0.0.0.0:56789", nullptr, 1, "", "");
     // register rpc before generic service is registered
 #ifndef NDEBUG
-    ASSERT_DEATH(g_grpc_server->register_generic_rpc(
-                     "method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }),
-                 "Assertion .* failed");
+    ASSERT_DEATH(
+        g_grpc_server->register_generic_rpc("method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }),
+        "Assertion .* failed");
 #else
-    EXPECT_FALSE(g_grpc_server->register_generic_rpc(
-        "method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
+    EXPECT_FALSE(
+        g_grpc_server->register_generic_rpc("method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
 #endif
 
     ASSERT_TRUE(g_grpc_server->register_async_generic_service());
@@ -369,21 +369,21 @@ TEST(GenericServiceDeathTest, basic_test) {
     EXPECT_FALSE(g_grpc_server->register_async_generic_service());
     // register rpc before server is run
 #ifndef NDEBUG
-    ASSERT_DEATH(g_grpc_server->register_generic_rpc(
-                     "method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }),
-                 "Assertion .* failed");
+    ASSERT_DEATH(
+        g_grpc_server->register_generic_rpc("method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }),
+        "Assertion .* failed");
 #else
-    EXPECT_FALSE(g_grpc_server->register_generic_rpc(
-        "method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
+    EXPECT_FALSE(
+        g_grpc_server->register_generic_rpc("method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
 #endif
     g_grpc_server->run();
-    EXPECT_TRUE(g_grpc_server->register_generic_rpc(
-        "method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
-    EXPECT_TRUE(g_grpc_server->register_generic_rpc(
-        "method2", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
+    EXPECT_TRUE(
+        g_grpc_server->register_generic_rpc("method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
+    EXPECT_TRUE(
+        g_grpc_server->register_generic_rpc("method2", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
     // re-register method 1
-    EXPECT_FALSE(g_grpc_server->register_generic_rpc(
-        "method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
+    EXPECT_FALSE(
+        g_grpc_server->register_generic_rpc("method1", [](boost::intrusive_ptr< GenericRpcData >&) { return true; }));
 
     auto client = std::make_unique< GrpcAsyncClient >("0.0.0.0:56789", "", "");
     client->init();
@@ -392,15 +392,11 @@ TEST(GenericServiceDeathTest, basic_test) {
     ::grpc::ByteBuffer cli_buf;
     generic_stub->call_unary(
         cli_buf, "method1",
-        [method = "method1"](::grpc::ByteBuffer&, ::grpc::Status& status) {
-            validate_generic_reply(method, status);
-        },
+        [method = "method1"](::grpc::ByteBuffer&, ::grpc::Status& status) { validate_generic_reply(method, status); },
         1);
     generic_stub->call_unary(
         cli_buf, "method2",
-        [method = "method2"](::grpc::ByteBuffer&, ::grpc::Status& status) {
-            validate_generic_reply(method, status);
-        },
+        [method = "method2"](::grpc::ByteBuffer&, ::grpc::Status& status) { validate_generic_reply(method, status); },
         1);
     generic_stub->call_unary(
         cli_buf, "method_unknown",

--- a/src/grpc/tests/unit/client_test.cpp
+++ b/src/grpc/tests/unit/client_test.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+
+#include "sisl/grpc/rpc_client.hpp"
+
+SISL_LOGGING_INIT(grpc_server)
+SISL_OPTIONS_ENABLE(logging)
+
+namespace sisltesting {
+using namespace sisl;
+using namespace ::grpc;
+
+static void SerializeToByteBuffer(ByteBuffer& buffer, std::string const& msg) {
+    buffer.Clear();
+    Slice slice(msg);
+    ByteBuffer tmp(&slice, 1);
+    buffer.Swap(&tmp);
+}
+
+static std::string DeserializeFromBuffer(ByteBuffer const& buffer) {
+    std::vector< grpc::Slice > slices;
+    (void)buffer.Dump(&slices);
+    std::string buf;
+    buf.reserve(buffer.Length());
+    for (auto s = slices.begin(); s != slices.end(); s++) {
+        buf.append(reinterpret_cast< const char* >(s->begin()), s->size());
+    }
+    return buf;
+}
+
+TEST(GenericClientResponseTest, movability_test) {
+    std::string msg("Hello");
+    ByteBuffer buffer;
+    SerializeToByteBuffer(buffer, msg);
+    GenericClientResponse resp1(buffer);
+    auto& b1 = resp1.response_blob();
+    auto buf1 = resp1.response_buf();
+    EXPECT_EQ(msg, DeserializeFromBuffer(buf1));
+    EXPECT_EQ(msg, std::string(reinterpret_cast< const char* >(b1.cbytes()), b1.size()));
+
+    // move construction
+    GenericClientResponse resp2(std::move(resp1));
+    auto& b2 = resp2.response_blob();
+    EXPECT_EQ(msg, std::string(b2.bytes(), b2.bytes() + b2.size()));
+    EXPECT_TRUE(resp2.response_buf().Valid());
+    EXPECT_EQ(b1.size(), 0);
+    EXPECT_EQ(b1.bytes(), nullptr);
+    EXPECT_FALSE(resp1.response_buf().Valid());
+    EXPECT_EQ(resp1.response_blob().size(), 0);
+    EXPECT_EQ(resp1.response_blob().bytes(), nullptr);
+
+    // move assignment
+    GenericClientResponse resp3 = std::move(resp2);
+    auto b3 = resp3.response_blob();
+    EXPECT_EQ(msg, std::string(b3.bytes(), b3.bytes() + b3.size()));
+    EXPECT_TRUE(resp3.response_buf().Valid());
+    EXPECT_EQ(b2.size(), 0);
+    EXPECT_EQ(b2.bytes(), nullptr);
+    EXPECT_FALSE(resp2.response_buf().Valid());
+    EXPECT_EQ(resp2.response_blob().size(), 0);
+    EXPECT_EQ(resp2.response_blob().bytes(), nullptr);
+}
+
+} // namespace sisltesting
+
+int main(int argc, char* argv[]) {
+    ::testing::InitGoogleMock(&argc, argv);
+    SISL_OPTIONS_LOAD(argc, argv, logging)
+    sisl::logging::SetLogger("auth_test");
+    int ret{RUN_ALL_TESTS()};
+    sisl::GrpcAsyncClientWorker::shutdown_all();
+    return ret;
+}

--- a/src/grpc/utils.hpp
+++ b/src/grpc/utils.hpp
@@ -19,7 +19,7 @@
 
 namespace sisl {
 
-static bool get_file_contents(const std::string& file_name, std::string& contents) {
+[[maybe_unused]] static bool get_file_contents(const std::string& file_name, std::string& contents) {
     try {
         std::ifstream f(file_name);
         std::string buffer(std::istreambuf_iterator< char >{f}, std::istreambuf_iterator< char >{});
@@ -59,15 +59,6 @@ static bool get_file_contents(const std::string& file_name, std::string& content
         std::memcpy(voidptr_cast(cli_buf.bytes()), c_voidptr_cast(slice.begin()), slice.size());
     }
     return status;
-}
-
-[[maybe_unused]] static sisl::io_blob_safe deserialize_from_byte_buffer(grpc::ByteBuffer const& cli_byte_buf) {
-    grpc::Slice slice;
-    auto status = cli_byte_buf.TrySingleSlice(&slice);
-    if (status.ok()) { return sisl::io_blob_safe(slice.begin(), slice.size(), false /* is alligned*/); }
-    auto cli_buf = sisl::io_blob_safe(slice.size());
-    std::memcpy(voidptr_cast(cli_buf.bytes()), c_voidptr_cast(slice.begin()), slice.size());
-    return cli_buf;
 }
 
 } // namespace sisl

--- a/src/grpc/utils.hpp
+++ b/src/grpc/utils.hpp
@@ -29,4 +29,45 @@ static bool get_file_contents(const std::string& file_name, std::string& content
     return false;
 }
 
-} // namespace sisl::grpc
+[[maybe_unused]] static void serialize_to_byte_buffer(io_blob_list_t const& cli_buf, grpc::ByteBuffer& cli_byte_buf) {
+    folly::small_vector< grpc::Slice, 4 > slices;
+    for (auto const& blob : cli_buf) {
+        slices.emplace_back(blob.cbytes(), blob.size(), grpc::Slice::STATIC_SLICE);
+    }
+    cli_byte_buf.Clear();
+    grpc::ByteBuffer tmp(slices.data(), cli_buf.size());
+    cli_byte_buf.Swap(&tmp);
+}
+
+[[maybe_unused]] static grpc::Status try_deserialize_from_byte_buffer(grpc::ByteBuffer const& cli_byte_buf,
+                                                                      io_blob& cli_buf) {
+    grpc::Slice slice;
+    auto status = cli_byte_buf.TrySingleSlice(&slice);
+    if (status.ok()) {
+        cli_buf.set_bytes(slice.begin());
+        cli_buf.set_size(slice.size());
+    }
+    return status;
+}
+
+[[maybe_unused]] static grpc::Status deserialize_from_byte_buffer(grpc::ByteBuffer const& cli_byte_buf,
+                                                                  io_blob& cli_buf) {
+    grpc::Slice slice;
+    auto status = cli_byte_buf.DumpToSingleSlice(&slice);
+    if (status.ok()) {
+        cli_buf.buf_alloc(slice.size());
+        std::memcpy(voidptr_cast(cli_buf.bytes()), c_voidptr_cast(slice.begin()), slice.size());
+    }
+    return status;
+}
+
+[[maybe_unused]] static sisl::io_blob_safe deserialize_from_byte_buffer(grpc::ByteBuffer const& cli_byte_buf) {
+    grpc::Slice slice;
+    auto status = cli_byte_buf.TrySingleSlice(&slice);
+    if (status.ok()) { return sisl::io_blob_safe(slice.begin(), slice.size(), false /* is alligned*/); }
+    auto cli_buf = sisl::io_blob_safe(slice.size());
+    std::memcpy(voidptr_cast(cli_buf.bytes()), c_voidptr_cast(slice.begin()), slice.size());
+    return cli_buf;
+}
+
+} // namespace sisl


### PR DESCRIPTION
Add a `call_unary` rpc to generic grpc client which accepts `sisl::io_blob_list_t` and returns a semi future of `client_response_ptr`. The user can access the grpc client response message in the form of `sisl::io_blob` by `client_response_ptr->response_blob()` and not worry about serialize and deserialize and keeping track of the buffer allocations.
The main changes are in rpc_client. The generic_service changes are just splitting them into cpp and header file and can be ignored