### PR TITLE
GenericClientResponse of grpc while copyable, reports memory leak, fixed that.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "12.1.1"
+    version = "12.2.1"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/grpc/rpc_client.hpp
+++ b/include/sisl/grpc/rpc_client.hpp
@@ -163,7 +163,7 @@ public:
     folly::Promise< Result< RespT > > m_promise;
 };
 
-class GenericClientResponse {
+class GenericClientResponse : public ObjLifeCounter< GenericClientResponse > {
 public:
     GenericClientResponse() = default;
     GenericClientResponse(grpc::ByteBuffer const& buf) : m_response_buf{buf} {}
@@ -171,11 +171,10 @@ public:
     GenericClientResponse(GenericClientResponse&& other);
     GenericClientResponse& operator=(GenericClientResponse&& other);
     GenericClientResponse(GenericClientResponse const& other) = default;
-    GenericClientResponse& operator=(GenericClientResponse const& other) = default;
+    GenericClientResponse& operator=(GenericClientResponse const& other);
     ~GenericClientResponse() = default;
 
     io_blob response_blob();
-    grpc::ByteBuffer const& response_buf(bool need_contiguous = true);
 
 private:
     grpc::ByteBuffer m_response_buf;

--- a/include/sisl/utility/obj_life_counter.hpp
+++ b/include/sisl/utility/obj_life_counter.hpp
@@ -145,7 +145,7 @@ struct ObjLifeCounter {
         s_alive.fetch_sub(1, std::memory_order_relaxed);
     }
 
-    ObjLifeCounter(const ObjLifeCounter& o) noexcept { s_alive.fetch_add(1, std::memory_order_relaxed); }
+    ObjLifeCounter(const ObjLifeCounter&) noexcept { s_alive.fetch_add(1, std::memory_order_relaxed); }
     static std::atomic< int64_t > s_created;
     static std::atomic< int64_t > s_alive;
     static ObjTypeWrapper< T > s_type;

--- a/src/grpc/tests/unit/client_test.cpp
+++ b/src/grpc/tests/unit/client_test.cpp
@@ -20,7 +20,7 @@ using namespace ::grpc;
     buffer.Swap(&tmp);
 }
 
-static std::string DeserializeFromBuffer(ByteBuffer const& buffer) {
+[[maybe_unused]] static std::string DeserializeFromBuffer(ByteBuffer const& buffer) {
     std::vector< grpc::Slice > slices;
     (void)buffer.Dump(&slices);
     std::string buf;
@@ -67,8 +67,7 @@ static std::string blob_to_string(io_blob const& b) { return std::string(c_charp
 static void do_test(std::string const& msg, grpc::ByteBuffer& bbuf) {
     GenericClientResponse resp1(bbuf);
     {
-        auto const& rbuf1 = resp1.response_buf();
-        EXPECT_EQ(msg, DeserializeFromBuffer(rbuf1));
+        // EXPECT_EQ(msg, DeserializeFromBuffer(rbuf1));
         EXPECT_EQ(msg, blob_to_string(resp1.response_blob()));
     }
 
@@ -76,9 +75,6 @@ static void do_test(std::string const& msg, grpc::ByteBuffer& bbuf) {
     GenericClientResponse resp2(std::move(resp1));
     {
         EXPECT_EQ(msg, blob_to_string(resp2.response_blob()));
-        EXPECT_TRUE(resp2.response_buf().Valid());
-
-        EXPECT_FALSE(resp1.response_buf().Valid());
         auto blb1 = resp1.response_blob();
         EXPECT_EQ(blb1.size(), 0);
         EXPECT_EQ(blb1.cbytes(), nullptr);
@@ -89,9 +85,6 @@ static void do_test(std::string const& msg, grpc::ByteBuffer& bbuf) {
     resp3 = std::move(resp2);
     {
         EXPECT_EQ(msg, blob_to_string(resp3.response_blob()));
-        EXPECT_TRUE(resp3.response_buf().Valid());
-
-        EXPECT_FALSE(resp2.response_buf().Valid());
         auto blb2 = resp2.response_blob();
         EXPECT_EQ(blb2.size(), 0);
         EXPECT_EQ(blb2.cbytes(), nullptr);
@@ -101,9 +94,6 @@ static void do_test(std::string const& msg, grpc::ByteBuffer& bbuf) {
     {
         GenericClientResponse resp4(resp3);
         EXPECT_EQ(msg, blob_to_string(resp4.response_blob()));
-        EXPECT_TRUE(resp4.response_buf().Valid());
-
-        EXPECT_TRUE(resp3.response_buf().Valid());
         EXPECT_EQ(msg, blob_to_string(resp3.response_blob()));
     }
 
@@ -112,9 +102,6 @@ static void do_test(std::string const& msg, grpc::ByteBuffer& bbuf) {
         GenericClientResponse resp5;
         resp5 = resp3;
         EXPECT_EQ(msg, blob_to_string(resp5.response_blob()));
-        EXPECT_TRUE(resp5.response_buf().Valid());
-
-        EXPECT_TRUE(resp3.response_buf().Valid());
         EXPECT_EQ(msg, blob_to_string(resp3.response_blob()));
     }
 }


### PR DESCRIPTION
GenericClientResponse of grpc while copyable, reports memory leak some cases. Fixed that by avoiding copy of the entire bytebuffer, but just the slice which is individually refcounted.

Added more allocator and minor improvements in buffer