### PR TITLE
Remove LRU cashe for tokens

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ required_conan_version = ">=1.52.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "8.6.8"
+    version = "8.7.0"
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"
     topics = ("ebay", "components", "core", "efficiency")

--- a/include/sisl/auth_manager/auth_manager.hpp
+++ b/include/sisl/auth_manager/auth_manager.hpp
@@ -60,11 +60,6 @@ private:
     virtual std::string download_key(const std::string& key_url) const;
     std::string get_app(const jwt::decoded_jwt& decoded) const;
 
-    // the verify method is declared const. We make this mutable
-    // as these caches are modified in the verify method. md5_sum(raw_token) ->
-    // DecodedToken
-    mutable LRUCache< std::string, CachedToken > m_cached_tokens;
-
     // key_id -> signing public key
     mutable LRUCache< std::string, std::string > m_cached_keys;
 };

--- a/include/sisl/auth_manager/trf_client.hpp
+++ b/include/sisl/auth_manager/trf_client.hpp
@@ -26,9 +26,10 @@ public:
 private:
     void validate_grant_path() const;
     bool grant_path_exists() const { return std::filesystem::exists(SECURITY_DYNAMIC_CONFIG(trf_client->grant_path)); }
+    // If leeway is set, this will force us to download token ahead of its expiry
     bool access_token_expired() const {
         return (std::chrono::system_clock::now() >
-                m_expiry + std::chrono::seconds(SECURITY_DYNAMIC_CONFIG(trf_client->trf_expiry_leeway_secs)));
+                m_expiry - std::chrono::seconds(SECURITY_DYNAMIC_CONFIG(trf_client->trf_expiry_leeway_secs)));
     }
     static bool get_file_contents(const std::string& file_name, std::string& contents);
 

--- a/include/sisl/auth_manager/trf_client.hpp
+++ b/include/sisl/auth_manager/trf_client.hpp
@@ -28,7 +28,7 @@ private:
     bool grant_path_exists() const { return std::filesystem::exists(SECURITY_DYNAMIC_CONFIG(trf_client->grant_path)); }
     bool access_token_expired() const {
         return (std::chrono::system_clock::now() >
-                m_expiry + std::chrono::seconds(SECURITY_DYNAMIC_CONFIG(auth_manager->leeway)));
+                m_expiry + std::chrono::seconds(SECURITY_DYNAMIC_CONFIG(trf_client->trf_expiry_leeway_secs)));
     }
     static bool get_file_contents(const std::string& file_name, std::string& contents);
 

--- a/src/auth_manager/auth_manager.cpp
+++ b/src/auth_manager/auth_manager.cpp
@@ -10,49 +10,9 @@ extern "C" {
 
 namespace sisl {
 
-static std::string md5_sum(std::string const& s) {
-    unsigned char digest[MD5_DIGEST_LENGTH];
-
-    MD5(reinterpret_cast< unsigned char* >(const_cast< char* >(s.c_str())), s.length(),
-        reinterpret_cast< unsigned char* >(&digest));
-
-    std::ostringstream out;
-    out << std::hex;
-    for (int i = 0; i < MD5_DIGEST_LENGTH; i++) {
-        out << std::setfill('0') << std::setw(2) << std::hex << (int)(unsigned char)digest[i];
-    }
-    return out.str();
-}
-
-struct incomplete_verification_error : std::exception {
-    explicit incomplete_verification_error(const std::string& error) : error_(error) {}
-    const char* what() const noexcept { return error_.c_str(); }
-
-private:
-    const std::string error_;
-};
-
-AuthManager::AuthManager() :
-        m_cached_tokens(SECURITY_DYNAMIC_CONFIG(auth_manager->auth_token_cache_size)),
-        m_cached_keys(SECURITY_DYNAMIC_CONFIG(auth_manager->auth_key_cache_size)) {}
+AuthManager::AuthManager() : m_cached_keys(SECURITY_DYNAMIC_CONFIG(auth_manager->auth_key_cache_size)) {}
 
 AuthVerifyStatus AuthManager::verify(const std::string& token, std::string& msg) const {
-    // if we have it in cache, just use it to make the decision
-    auto const token_hash = md5_sum(token);
-    if (auto const ct = m_cached_tokens.get(token_hash); ct) {
-        if (ct->valid) {
-            auto now = std::chrono::system_clock::now();
-            if (now > ct->expires_at + std::chrono::seconds(SECURITY_DYNAMIC_CONFIG(auth_manager->leeway))) {
-                m_cached_tokens.put(token_hash,
-                                    CachedToken{AuthVerifyStatus::UNAUTH, "token expired", false, ct->expires_at});
-            }
-        }
-        msg = ct->msg;
-        return ct->response_status;
-    }
-
-    // not found in cache
-    CachedToken cached_token;
     std::string app_name;
     try {
         // this may throw if token is ill formed
@@ -62,32 +22,20 @@ AuthVerifyStatus AuthManager::verify(const std::string& token, std::string& msg)
         // exception is thrown.
         verify_decoded(decoded);
         app_name = get_app(decoded);
-        cached_token.expires_at = decoded.get_expires_at();
-        cached_token.set_valid();
-    } catch (const incomplete_verification_error& e) {
-        // verification incomplete, the token validity is not determined, shouldn't
-        // cache
+    } catch (const std::exception& e) {
         msg = e.what();
         return AuthVerifyStatus::UNAUTH;
-    } catch (const std::exception& e) {
-        cached_token.set_invalid(AuthVerifyStatus::UNAUTH, e.what());
-        m_cached_tokens.put(token_hash, cached_token);
-        msg = cached_token.msg;
-        return cached_token.response_status;
     }
 
     // check client application
-
     if (SECURITY_DYNAMIC_CONFIG(auth_manager->auth_allowed_apps) != "all") {
         if (SECURITY_DYNAMIC_CONFIG(auth_manager->auth_allowed_apps).find(app_name) == std::string::npos) {
-            cached_token.set_invalid(AuthVerifyStatus::FORBIDDEN,
-                                     fmt::format("application '{}' is not allowed to perform the request", app_name));
+            msg = fmt::format("application '{}' is not allowed to perform the request", app_name);
+            return AuthVerifyStatus::FORBIDDEN;
         }
     }
 
-    m_cached_tokens.put(token_hash, cached_token);
-    msg = cached_token.msg;
-    return cached_token.response_status;
+    return AuthVerifyStatus::OK;
 }
 
 void AuthManager::verify_decoded(const jwt::decoded_jwt& decoded) const {
@@ -125,7 +73,9 @@ void AuthManager::verify_decoded(const jwt::decoded_jwt& decoded) const {
     const auto verifier{jwt::verify()
                             .with_issuer(SECURITY_DYNAMIC_CONFIG(auth_manager->issuer))
                             .allow_algorithm(jwt::algorithm::rs256(signing_key))
-                            .expires_at_leeway(SECURITY_DYNAMIC_CONFIG(auth_manager->leeway))};
+                            .expires_at_leeway(SECURITY_DYNAMIC_CONFIG(auth_manager->expiry_leeway_secs))
+                            .issued_at_leeway(SECURITY_DYNAMIC_CONFIG(auth_manager->iat_leeway_secs))
+                            .not_before_leeway(SECURITY_DYNAMIC_CONFIG(auth_manager->nbf_leeway_secs))};
 
     // if verification fails, an instance of std::system_error subclass is thrown.
     verifier.verify(decoded);

--- a/src/auth_manager/security_config.fbs
+++ b/src/auth_manager/security_config.fbs
@@ -12,7 +12,7 @@ table TrfClient {
     server: string;
 
     // Leeway for an expired token
-    trf_expiry_leeway_secs: uint32 = 0;
+    trf_expiry_leeway_secs: uint32 = 300;
 
     // Pod env variables
     app_name: string;
@@ -32,13 +32,13 @@ table AuthManager {
     tf_token_url: string;
 
     // leeway to the token expiration
-    expiry_leeway_secs: uint32 = 300;
+    expiry_leeway_secs: uint32 = 0;
 
     // leeway to the token issued_at
-    iat_leeway_secs: uint32 = 120;
+    iat_leeway_secs: uint32 = 5;
 
     // leeway to the token not_before
-    nbf_leeway_secs: uint32 = 120;
+    nbf_leeway_secs: uint32 = 5;
 
     // ssl verification for the signing key download url
     verify: bool = true;

--- a/src/auth_manager/security_config.fbs
+++ b/src/auth_manager/security_config.fbs
@@ -11,6 +11,9 @@ table TrfClient {
     // Server addr to download the token (default: https://trustfabric.vip.ebay.com/v2/token)
     server: string;
 
+    // Leeway for an expired token
+    trf_expiry_leeway_secs: uint32 = 0;
+
     // Pod env variables
     app_name: string;
     app_inst_name: string;
@@ -29,13 +32,18 @@ table AuthManager {
     tf_token_url: string;
 
     // leeway to the token expiration
-    leeway: uint32 = 0;
+    expiry_leeway_secs: uint32 = 300;
+
+    // leeway to the token issued_at
+    iat_leeway_secs: uint32 = 120;
+
+    // leeway to the token not_before
+    nbf_leeway_secs: uint32 = 120;
 
     // ssl verification for the signing key download url
     verify: bool = true;
 
-    // LRUCache sizes
-    auth_token_cache_size: uint32 = 2000;
+    // LRUCache size
     auth_key_cache_size: uint32 = 100;
 }
 


### PR DESCRIPTION
Fix token expired issue due to time drift in issued_at claim,, more info https://jirap.corp.ebay.com/browse/SDSTOR-13615?filter=-1
Remove the LRU cache we use for the tokens and use the jwt verifier to verify every time. Add leeways for issued_at and not_before claims as an optimization. 
Also, add leeway to trf client to download token ahead of its expiry.