### PR TITLE
Virtual destructor for Obj life Counter

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "8.9.0"
+    version = "8.9.1"
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"
     topics = ("ebay", "components", "core", "efficiency")

--- a/include/sisl/utility/obj_life_counter.hpp
+++ b/include/sisl/utility/obj_life_counter.hpp
@@ -140,7 +140,7 @@ struct ObjLifeCounter {
         s_type.m_dummy = 0; // To keep s_type initialized during compile time
     }
 
-    ~ObjLifeCounter() {
+    virtual ~ObjLifeCounter() {
         assert(s_alive.load() > 0);
         s_alive.fetch_sub(1, std::memory_order_relaxed);
     }


### PR DESCRIPTION
make the destructor of obj life counter virtual for its destructor to be called when the derived class is destructed