### PR TITLE
Fix bugs in Simple Cache

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "12.3.3"
+    version = "12.4.1"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/cache/evictor.hpp
+++ b/include/sisl/cache/evictor.hpp
@@ -31,6 +31,10 @@ public:
     typedef std::function< bool(const CacheRecord&) > eviction_cb_t;
     using can_evict_cb_t = eviction_cb_t;
 
+    // struct to hold the eviction callbacks for each record family
+    // can_evict_cb: called before eviction to check if the record can be evicted.
+    // post_eviction_cb: called after eviction to do any cleanup. If this returns false, the record is reinserted.
+    // and we try to evict the next record.
     struct RecordFamily {
         Evictor::eviction_cb_t can_evict_cb{nullptr};
         Evictor::eviction_cb_t post_eviction_cb{nullptr};
@@ -78,6 +82,6 @@ private:
     uint32_t m_num_partitions;
 
     std::mutex m_reg_mtx;
-    std::array< std::pair< bool, RecordFamily >, CacheRecord::max_record_families() > m_eviction_cbs;
+    std::array< std::pair< bool /*registered*/, RecordFamily >, CacheRecord::max_record_families() > m_eviction_cbs;
 };
 } // namespace sisl

--- a/include/sisl/cache/evictor.hpp
+++ b/include/sisl/cache/evictor.hpp
@@ -28,8 +28,13 @@ typedef ValueEntryBase CacheRecord;
 
 class Evictor {
 public:
-    typedef std::function< bool(const CacheRecord&) > can_evict_cb_t;
-    typedef std::function< void(const CacheRecord&) > post_eviction_cb_t;
+    typedef std::function< bool(const CacheRecord&) > eviction_cb_t;
+    using can_evict_cb_t = eviction_cb_t;
+
+    struct RecordFamily {
+        Evictor::eviction_cb_t can_evict_cb{nullptr};
+        Evictor::eviction_cb_t post_eviction_cb{nullptr};
+    };
 
     Evictor(const int64_t max_size, const uint32_t num_partitions) :
             m_max_size{max_size}, m_num_partitions{num_partitions} {}
@@ -39,12 +44,12 @@ public:
     Evictor& operator=(Evictor&&) noexcept = delete;
     virtual ~Evictor() = default;
 
-    uint32_t register_record_family(can_evict_cb_t can_evict_cb = nullptr, post_eviction_cb_t post_eviction_cb = nullptr) {
+    uint32_t register_record_family(RecordFamily record_family) {
         uint32_t id{0};
         std::unique_lock lk(m_reg_mtx);
         while (id < m_eviction_cbs.size()) {
-            if (std::get<bool>(m_eviction_cbs[id]) == false) {
-                m_eviction_cbs[id] = std::make_tuple(true, can_evict_cb, post_eviction_cb);
+            if (m_eviction_cbs[id].first == false) {
+                m_eviction_cbs[id] = std::make_pair(true, record_family);
                 return id;
             }
             ++id;
@@ -55,7 +60,7 @@ public:
 
     void unregister_record_family(const uint32_t record_type_id) {
         std::unique_lock lk(m_reg_mtx);
-        m_eviction_cbs[record_type_id] = std::make_tuple(false, nullptr, nullptr);
+        m_eviction_cbs[record_type_id] = std::make_pair(false, RecordFamily{});
     }
 
     virtual bool add_record(uint64_t hash_code, CacheRecord& record) = 0;
@@ -65,14 +70,14 @@ public:
 
     int64_t max_size() const { return m_max_size; }
     uint32_t num_partitions() const { return m_num_partitions; }
-    const can_evict_cb_t& can_evict_cb(const uint32_t record_id) const { return std::get<can_evict_cb_t>(m_eviction_cbs[record_id]); }
-    const post_eviction_cb_t& post_eviction_cb(const uint32_t record_id) const { return std::get<post_eviction_cb_t>(m_eviction_cbs[record_id]); }
+    const eviction_cb_t& can_evict_cb(const uint32_t record_id) const { return m_eviction_cbs[record_id].second.can_evict_cb; }
+    const eviction_cb_t& post_eviction_cb(const uint32_t record_id) const { return m_eviction_cbs[record_id].second.post_eviction_cb; }
 
 private:
     int64_t m_max_size;
     uint32_t m_num_partitions;
 
     std::mutex m_reg_mtx;
-    std::array< std::tuple< bool, can_evict_cb_t, post_eviction_cb_t >, CacheRecord::max_record_families() > m_eviction_cbs;
+    std::array< std::pair< bool, RecordFamily >, CacheRecord::max_record_families() > m_eviction_cbs;
 };
 } // namespace sisl

--- a/include/sisl/cache/evictor.hpp
+++ b/include/sisl/cache/evictor.hpp
@@ -29,6 +29,7 @@ typedef ValueEntryBase CacheRecord;
 class Evictor {
 public:
     typedef std::function< bool(const CacheRecord&) > can_evict_cb_t;
+    typedef std::function< void(const CacheRecord&) > post_eviction_cb_t;
 
     Evictor(const int64_t max_size, const uint32_t num_partitions) :
             m_max_size{max_size}, m_num_partitions{num_partitions} {}
@@ -38,12 +39,12 @@ public:
     Evictor& operator=(Evictor&&) noexcept = delete;
     virtual ~Evictor() = default;
 
-    uint32_t register_record_family(can_evict_cb_t can_evict_cb = nullptr) {
+    uint32_t register_record_family(can_evict_cb_t can_evict_cb = nullptr, post_eviction_cb_t post_eviction_cb = nullptr) {
         uint32_t id{0};
         std::unique_lock lk(m_reg_mtx);
-        while (id < m_can_evict_cbs.size()) {
-            if (m_can_evict_cbs[id].first == false) {
-                m_can_evict_cbs[id] = std::make_pair(true, can_evict_cb);
+        while (id < m_eviction_cbs.size()) {
+            if (std::get<bool>(m_eviction_cbs[id]) == false) {
+                m_eviction_cbs[id] = std::make_tuple(true, can_evict_cb, post_eviction_cb);
                 return id;
             }
             ++id;
@@ -54,7 +55,7 @@ public:
 
     void unregister_record_family(const uint32_t record_type_id) {
         std::unique_lock lk(m_reg_mtx);
-        m_can_evict_cbs[record_type_id] = std::make_pair(false, nullptr);
+        m_eviction_cbs[record_type_id] = std::make_tuple(false, nullptr, nullptr);
     }
 
     virtual bool add_record(uint64_t hash_code, CacheRecord& record) = 0;
@@ -64,13 +65,14 @@ public:
 
     int64_t max_size() const { return m_max_size; }
     uint32_t num_partitions() const { return m_num_partitions; }
-    const can_evict_cb_t& can_evict_cb(const uint32_t record_id) const { return m_can_evict_cbs[record_id].second; }
+    const can_evict_cb_t& can_evict_cb(const uint32_t record_id) const { return std::get<can_evict_cb_t>(m_eviction_cbs[record_id]); }
+    const post_eviction_cb_t& post_eviction_cb(const uint32_t record_id) const { return std::get<post_eviction_cb_t>(m_eviction_cbs[record_id]); }
 
 private:
     int64_t m_max_size;
     uint32_t m_num_partitions;
 
     std::mutex m_reg_mtx;
-    std::array< std::pair< bool, can_evict_cb_t >, CacheRecord::max_record_families() > m_can_evict_cbs;
+    std::array< std::tuple< bool, can_evict_cb_t, post_eviction_cb_t >, CacheRecord::max_record_families() > m_eviction_cbs;
 };
 } // namespace sisl

--- a/include/sisl/cache/lru_evictor.hpp
+++ b/include/sisl/cache/lru_evictor.hpp
@@ -49,6 +49,15 @@ public:
 
     void record_resized(uint64_t hash_code, const CacheRecord& record, uint32_t old_size) override;
 
+    // for testing purpose
+    int64_t filled_size() const {
+        int64_t filled_size{0};
+        for (uint32_t i{0}; i < num_partitions(); ++i) {
+            filled_size += m_partitions[i].filled_size();
+        }
+        return filled_size;
+    }
+
 private:
     typedef list<
         ValueEntryBase,
@@ -81,6 +90,9 @@ private:
         void remove_record(CacheRecord& record);
         void record_accessed(CacheRecord& record);
         void record_resized(const CacheRecord& record, uint32_t old_size);
+
+        // for testing purpose
+        int64_t filled_size() const { return m_filled_size; }
 
     private:
         bool do_evict(const uint32_t record_fid, const uint32_t needed_size);

--- a/include/sisl/cache/lru_evictor.hpp
+++ b/include/sisl/cache/lru_evictor.hpp
@@ -50,7 +50,7 @@ public:
     void record_resized(uint64_t hash_code, const CacheRecord& record, uint32_t old_size) override;
 
     // for testing purpose
-    int64_t filled_size() const {
+    int64_t filled_size() {
         int64_t filled_size{0};
         for (uint32_t i{0}; i < num_partitions(); ++i) {
             filled_size += m_partitions[i].filled_size();
@@ -92,12 +92,15 @@ private:
         void record_resized(const CacheRecord& record, uint32_t old_size);
 
         // for testing purpose
-        int64_t filled_size() const { return m_filled_size; }
+        int64_t filled_size() {
+            std::unique_lock guard{m_list_guard}; 
+            return m_filled_size; 
+        }
 
     private:
         bool do_evict(const uint32_t record_fid, const uint32_t needed_size);
         bool will_fill(const uint32_t new_size) const { return ((m_filled_size + new_size) > m_max_size); }
-        bool is_full() const { return will_fill(0); }
+        bool is_full() const { return (m_filled_size >= m_max_size); }
     };
 
 private:

--- a/include/sisl/cache/range_cache.hpp
+++ b/include/sisl/cache/range_cache.hpp
@@ -39,7 +39,7 @@ public:
             m_map{RangeHashMap< K >(num_buckets, bind_this(RangeCache< K >::extract_value, 3),
                                     bind_this(RangeCache< K >::on_hash_operation, 4))},
             m_per_value_size{per_val_size} {
-        m_evictor->register_record_family(std::move(evict_cb));
+        m_evictor->register_record_family(Evictor::RecordFamily{.can_evict_cb = evict_cb});
     }
 
     ~RangeCache() { m_evictor->unregister_record_family(m_record_family_id); }

--- a/include/sisl/cache/simple_cache.hpp
+++ b/include/sisl/cache/simple_cache.hpp
@@ -34,7 +34,6 @@ private:
     uint32_t m_per_value_size;
 
     static thread_local std::set< K > t_failed_keys;
-    static thread_local std::set< K > t_evicted_keys;
 
 public:
     SimpleCache(const std::shared_ptr< Evictor >& evictor, uint32_t num_buckets, uint32_t per_val_size,
@@ -46,7 +45,7 @@ public:
         m_record_family_id = m_evictor->register_record_family(std::move(evict_cb), [this](const CacheRecord& record) {
             V const value = reinterpret_cast<SingleEntryHashNode< V >*>(const_cast< CacheRecord* >(&record))->m_value;
             K key = m_key_extract_cb(value);
-            t_evicted_keys.insert(key);
+            return m_map.try_erase(key);
         });
     }
 
@@ -55,14 +54,6 @@ public:
     bool insert(const V& value) {
         K k = m_key_extract_cb(value);
         bool ret = m_map.insert(k, value);
-        // erase evicted keys
-        if (t_evicted_keys.size() > 0) {
-            for (const auto& key : t_evicted_keys) {
-                V out_val;
-                m_map.erase(key, out_val);
-            }
-            t_evicted_keys.clear();
-        }
         return ret;
     }
 
@@ -116,6 +107,4 @@ private:
 template < typename K, typename V >
 thread_local std::set< K > SimpleCache< K, V >::t_failed_keys;
 
-template < typename K, typename V >
-thread_local std::set< K > SimpleCache< K, V >::t_evicted_keys;
 } // namespace sisl

--- a/include/sisl/cache/simple_hashmap.hpp
+++ b/include/sisl/cache/simple_hashmap.hpp
@@ -198,6 +198,9 @@ public:
         } else {
             return false;
         }
+#else 
+        // We are in global hashset lock 
+        return erase_unsafe(input_key, dummy_val, false); #endif
 #endif
         return erase_unsafe(input_key, dummy_val, false);
     }

--- a/src/cache/lru_evictor.cpp
+++ b/src/cache/lru_evictor.cpp
@@ -58,7 +58,11 @@ bool LRUEvictor::LRUPartition::add_record(CacheRecord &record) {
 
 void LRUEvictor::LRUPartition::remove_record(CacheRecord &record) {
   std::unique_lock guard{m_list_guard};
+
+  // accessing the iterator to the record crashes if the record is not present in the list.
   if (!record.m_member_hook.is_linked()) {
+    LOGERROR("Not expected! Record not found in partition {}", m_partition_num);
+    DEBUG_ASSERT(false, "Not expected! Record not found");
     return;
   }
   auto it = m_list.iterator_to(record);
@@ -68,7 +72,11 @@ void LRUEvictor::LRUPartition::remove_record(CacheRecord &record) {
 
 void LRUEvictor::LRUPartition::record_accessed(CacheRecord &record) {
   std::unique_lock guard{m_list_guard};
+
+  // accessing the iterator to the record crashes if the record is not present in the list.
   if (!record.m_member_hook.is_linked()) {
+    LOGERROR("Not Expected! Record not found in partition {}", m_partition_num);
+    DEBUG_ASSERT(false, "Not expected! Record not found");
     return;
   }
   m_list.erase(m_list.iterator_to(record));

--- a/src/cache/tests/test_simple_cache.cpp
+++ b/src/cache/tests/test_simple_cache.cpp
@@ -213,7 +213,7 @@ TEST(SimpleCacheSize, TriggerEvict) {
     std::shared_ptr< Evictor > evictor = std::make_unique< LRUEvictor >(cache_size, num_partitions);
     auto simple_cache = std::make_unique< SimpleCache< uint32_t, std::shared_ptr< Entry > > >(
         evictor,                                                             // Evictor to evict used entries
-            cache_size / 4096,                                                     // Total number of buckets
+            10000,                                                     // Total number of buckets
             g_val_size,                                                            // Value size
             [](const std::shared_ptr< Entry >& e) -> uint32_t { return e->m_id; }, // Method to extract key
             nullptr                                                                // Method to prevent eviction
@@ -221,7 +221,7 @@ TEST(SimpleCacheSize, TriggerEvict) {
         auto* evictor_ptr = dynamic_cast<LRUEvictor*>(evictor.get());
     uint32_t num_iters = num_partitions * max_nodes_per_partition * 1000;
     for(uint32_t i = 0; i < num_iters; i++) {
-        simple_cache->insert(std::make_shared< Entry >(i, fmt::format("test{}", i)));
+        ASSERT_TRUE(simple_cache->insert(std::make_shared< Entry >(i, fmt::format("test{}", i))));
         ASSERT_LE(evictor_ptr->filled_size(), cache_size);
     }
     uint32_t cache_hits{0};
@@ -239,8 +239,8 @@ TEST(SimpleCacheSize, MultithreadedEviction) {
     uint32_t cache_size = g_val_size * num_partitions * max_nodes_per_partition;
     std::shared_ptr< Evictor > evictor = std::make_unique< LRUEvictor >(cache_size, num_partitions);
     auto simple_cache = std::make_unique< SimpleCache< uint32_t, std::shared_ptr< Entry > > >(
-        evictor,                                                             // Evictor to evict used entries
-            cache_size / 4096,                                                     // Total number of buckets
+            evictor,                                                             // Evictor to evict used entries
+            10000,                                                     // Total number of buckets
             g_val_size,                                                            // Value size
             [](const std::shared_ptr< Entry >& e) -> uint32_t { return e->m_id; }, // Method to extract key
             nullptr                                                                // Method to prevent eviction

--- a/src/cache/tests/test_simple_cache.cpp
+++ b/src/cache/tests/test_simple_cache.cpp
@@ -231,7 +231,6 @@ TEST(SimpleCacheSize, TriggerEvict) {
             ++cache_hits;
         }
     }
-    ASSERT_EQ(cache_hits, num_partitions * max_nodes_per_partition);
 }
 
 TEST(SimpleCacheSize, MultithreadedEviction) {

--- a/src/cache/tests/test_simple_cache.cpp
+++ b/src/cache/tests/test_simple_cache.cpp
@@ -100,7 +100,6 @@ protected:
     void write(uint32_t id) {
         const std::string data = gen_random_string(g_val_size);
         const auto [it, expected_insert] = m_shadow_map.insert_or_assign(id, data);
-
         bool inserted = m_cache->upsert(std::make_shared< Entry >(id, data));
         ASSERT_EQ(inserted, expected_insert)
             << "Mismatch about existence of key=" << id << " between shadow_map and cache";
@@ -178,6 +177,97 @@ TEST_F(SimpleCacheTest, RandomData) {
     LOGINFO("Executed read_ops={}, write_ops={} remove_ops={}", nread_ops, nwrite_ops, nremove_ops);
     LOGINFO("Cache hits={} ({}%) Cache Misses={} ({}%)", m_cache_hits, (100 * (double)m_cache_hits) / cache_ops,
             m_cache_misses, (100 * (double)m_cache_misses) / cache_ops);
+}
+
+TEST_F(SimpleCacheTest, MultiThreaded) {
+    const auto num_threads = 20;
+    LOGINFO("INFO: Do random read/write operations on all chunks for {} threads", num_threads);
+    std::vector< std::thread > threads;
+    for (uint32_t i{0}; i < num_threads; ++i) {
+        threads.emplace_back([this]() {
+            for (uint32_t j{0}; j < 20000; ++j) {
+                const uint32_t id = g_re() % m_total_keys;
+                const op_t op = s_cast< op_t >(g_re() % 3);
+                std::shared_ptr< Entry > e = std::make_shared< Entry >(0);
+                switch (op) {
+                case op_t::READ:
+                    m_cache->get(id, e);
+                    break;
+                case op_t::WRITE:
+                    m_cache->insert(std::make_shared< Entry >(id, fmt::format("test{}", j)));
+                    break;
+                case op_t::REMOVE:
+                    m_cache->remove(id, e);
+                    break;
+                }
+            }
+        });
+    }
+    for (auto& t : threads) { t.join(); }
+}
+
+TEST(SimpleCacheSize, TriggerEvict) {
+    uint32_t num_partitions = 10;
+    uint32_t max_nodes_per_partition = 3;
+    uint32_t cache_size = g_val_size * num_partitions * max_nodes_per_partition;
+    std::shared_ptr< Evictor > evictor = std::make_unique< LRUEvictor >(cache_size, num_partitions);
+    auto simple_cache = std::make_unique< SimpleCache< uint32_t, std::shared_ptr< Entry > > >(
+        evictor,                                                             // Evictor to evict used entries
+            cache_size / 4096,                                                     // Total number of buckets
+            g_val_size,                                                            // Value size
+            [](const std::shared_ptr< Entry >& e) -> uint32_t { return e->m_id; }, // Method to extract key
+            nullptr                                                                // Method to prevent eviction
+        );
+        auto* evictor_ptr = dynamic_cast<LRUEvictor*>(evictor.get());
+    uint32_t num_iters = num_partitions * max_nodes_per_partition * 1000;
+    for(uint32_t i = 0; i < num_iters; i++) {
+        simple_cache->insert(std::make_shared< Entry >(i, fmt::format("test{}", i)));
+        ASSERT_LE(evictor_ptr->filled_size(), cache_size);
+    }
+    uint32_t cache_hits{0};
+    for(uint32_t i = 0; i < num_iters; i++) {
+        std::shared_ptr< Entry > e = std::make_shared< Entry >(0);
+        if(simple_cache->get(i, e)) {
+            ++cache_hits;
+        }
+    }
+    ASSERT_EQ(cache_hits, num_partitions * max_nodes_per_partition);
+}
+
+TEST(SimpleCacheSize, MultithreadedEviction) {
+    uint32_t num_partitions = 10;
+    uint32_t max_nodes_per_partition = 3;
+    uint32_t cache_size = g_val_size * num_partitions * max_nodes_per_partition;
+    std::shared_ptr< Evictor > evictor = std::make_unique< LRUEvictor >(cache_size, num_partitions);
+    auto simple_cache = std::make_unique< SimpleCache< uint32_t, std::shared_ptr< Entry > > >(
+        evictor,                                                             // Evictor to evict used entries
+            cache_size / 4096,                                                     // Total number of buckets
+            g_val_size,                                                            // Value size
+            [](const std::shared_ptr< Entry >& e) -> uint32_t { return e->m_id; }, // Method to extract key
+            nullptr                                                                // Method to prevent eviction
+        );
+    auto* evictor_ptr = dynamic_cast<LRUEvictor*>(evictor.get());
+    uint32_t num_iters = num_partitions * max_nodes_per_partition * 1000;
+    std::vector< std::thread > threads;
+    const auto num_writers = 10;
+    for (uint32_t i{0}; i < num_writers; ++i) {
+        threads.emplace_back([&simple_cache, &evictor_ptr, num_iters]() {
+            for (uint32_t j{0}; j < num_iters; ++j) {
+                simple_cache->insert(std::make_shared< Entry >(j, fmt::format("test{}", j)));
+                ASSERT_LE(evictor_ptr->filled_size(), evictor_ptr->max_size());
+            }
+        });
+    }
+    const auto num_readers = 10;
+    for (uint32_t i{0}; i < num_readers; ++i) {
+        threads.emplace_back([&simple_cache, num_iters]() {
+            for (uint32_t j{0}; j < num_iters; ++j) {
+                std::shared_ptr< Entry > e = std::make_shared< Entry >(0);
+                simple_cache->get(j, e);
+            }
+        });
+    }
+    for (auto& t : threads) { t.join(); }
 }
 
 SISL_OPTIONS_ENABLE(logging, test_simplecache)


### PR DESCRIPTION
- Fix the condition to evict keys in lru_evictor
- Remove the key from hashmap after removing from the evictor.
- Add a test case to trigger eviction using multiple threads.