### PR TITLE
Improve file watcher

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "12.4.2"
+    version = "12.4.3"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/file_watcher/file_watcher.hpp
+++ b/include/sisl/file_watcher/file_watcher.hpp
@@ -34,6 +34,7 @@ private:
     void run();
     void handle_events();
     void get_fileinfo(const int wd, FileInfo& file_info) const;
+    void set_fileinfo_content(const int wd, const std::string&);
     void on_modified_event(const int wd, const bool is_deleted);
     bool remove_watcher(FileInfo& file_info);
     static bool get_file_contents(const std::string& file_name, std::string& contents);


### PR DESCRIPTION
1. fixed the bug that filecontent in fileinfo never get updated.

2. only trigger on_modify when file closed, avoid unnecessary noice.