### PR TITLE
Fix build complains

### DIFF
--- a/include/sisl/auth_manager/token_verifier.hpp
+++ b/include/sisl/auth_manager/token_verifier.hpp
@@ -42,7 +42,7 @@ class GrpcTokenVerifier : public TokenVerifier {
 public:
     explicit GrpcTokenVerifier(std::string const& auth_header_key) : m_auth_header_key(auth_header_key) {}
     virtual ~GrpcTokenVerifier() = default;
-
+    using TokenVerifier::verify;
     virtual grpc::Status verify(grpc::ServerContext const* srv_ctx) const = 0;
 
 protected:


### PR DESCRIPTION
In file included from /root/.conan2/p/b/sisl6d3b4dcd770ec/b/include/sisl/grpc/rpc_server.hpp:25,
                 from /root/.conan2/p/b/sisl6d3b4dcd770ec/b/src/grpc/rpc_server.cpp:15:
/root/.conan2/p/b/sisl6d3b4dcd770ec/b/include/sisl/auth_manager/token_verifier.hpp:37:29: error: 'virtual sisl::token_state_ptr sisl::TokenVerifier::verify(const std::string&) const' was hidden [-Werror=overloaded-virtual=]
   37 |     virtual token_state_ptr verify(std::string const& token) const = 0;
      |                             ^~~~~~
/root/.conan2/p/b/sisl6d3b4dcd770ec/b/include/sisl/auth_manager/token_verifier.hpp:46:26: note:   by 'virtual grpc::Status sisl::GrpcTokenVerifier::verify(const grpc::ServerContext*) const'
   46 |     virtual grpc::Status verify(grpc::ServerContext const* srv_ctx) const = 0;
      |                          ^~~~~~
cc1plus: all warnings being treated as errors