### PR TITLE
Add LowResolutionLatecyBuckets.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "12.4.5"
+    version = "12.4.6"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/metrics/histogram_buckets.hpp
+++ b/include/sisl/metrics/histogram_buckets.hpp
@@ -32,6 +32,7 @@ typedef std::vector< double > hist_bucket_boundaries_t;
                                                                                                                        \
     X(OpLatecyBuckets, 10, 50, 100, 150, 200, 300, 400, 500, 750, 1000, 1500, 2000, 5000, 10000, 20000, 50000, 100000, \
       200000, 300000, 2000000)                                                                                         \
+    X(LowResolutionLatecyBuckets, 100, 500, 1000, 5000, 10000, 50000, 100000, 200000, 300000, 2000000)                 \
                                                                                                                        \
     X(ExponentialOfTwoBuckets, 1, exp2(4), exp2(7), exp2(10), exp2(13), exp2(16), exp2(19), exp2(22), exp2(25),        \
       exp2(28), exp2(31))                                                                                              \


### PR DESCRIPTION
The OpLatecyBuckets has 20 buckets which is way too large for those per RaftGroup/per Volume histogram.

Reducing cardinality for those metrics that trend is more important than accuraciy.