### PR TITLE
Fix use-after-move in byte_view(byte_array) constructor

### DIFF
--- a/include/sisl/fds/buffer.hpp
+++ b/include/sisl/fds/buffer.hpp
@@ -444,7 +444,12 @@ public:
         m_view.set_bytes(m_base_buf->cbytes());
         m_view.set_size(m_base_buf->size());
     }
-    byte_view(byte_array buf) : byte_view(std::move(buf), 0u, buf->size()) {}
+    byte_view(byte_array buf) {
+        auto sz = buf->size();
+        m_base_buf = std::move(buf);
+        m_view.set_bytes(m_base_buf->cbytes());
+        m_view.set_size(sz);
+    }
     byte_view(byte_array buf, uint32_t offset, uint32_t sz) {
         m_base_buf = std::move(buf);
         m_view.set_bytes(m_base_buf->cbytes() + offset);


### PR DESCRIPTION
The delegating constructor `byte_view(std::move(buf), 0u, buf->size())` has unspecified argument evaluation order in C++. On aarch64 (Graviton), the compiler move-constructs the first parameter before evaluating `buf->size()`, causing a null dereference segfault.

Capture size before moving to ensure well-defined evaluation order.