### PR TITLE
Add sisl::HttpServer as an optional http component

### DIFF
--- a/3rd_party/pistache/conandata.yml
+++ b/3rd_party/pistache/conandata.yml
@@ -1,0 +1,38 @@
+sources:
+  "nbi.0.0.5.1":
+    url: "https://github.com/pistacheio/pistache/archive/refs/tags/0.0.5.tar.gz"
+    sha256: "e2da87ebc01367e33bd8d7800cb2bf5c23e9fb4e6f49dce2cab5f8756df8dca0"
+  "0.0.5":
+    url: "https://github.com/pistacheio/pistache/archive/refs/tags/0.0.5.tar.gz"
+    sha256: "e2da87ebc01367e33bd8d7800cb2bf5c23e9fb4e6f49dce2cab5f8756df8dca0"
+  "cci.20240107":
+    url: "https://github.com/pistacheio/pistache/archive/1c733a145b01a4737cf5c7dd3709bd85be404886.tar.gz"
+    sha256: "156d2a4503be3d6c0726009c83e6d2e6e2e6378e6136436fc2d82d13597b6b0b"
+  "cci.20201127":
+    url: "https://github.com/pistacheio/pistache/archive/a3c5c68e0f08e19331d53d12846079ad761fe974.tar.gz"
+    sha256: "f1abb9e43ff847ebff8edb72623c9942162df134bccfb571af9c7817d3261fae"
+patches:
+  "nbi.0.0.5.1":
+    - patch_file: "patches/0.0.5-0001-include-cstdint.patch"
+      patch_description: "include <stddef>"
+      patch_type: "portability"
+      patch_source: "https://github.com/pistacheio/pistache/pull/1142"
+    - patch_file: "patches/0.0.5-0002-disable-older-tls.patch"
+      patch_description: "disable tls1 and tls1.1"
+  "0.0.5":
+    - patch_file: "patches/0.0.5-0001-include-cstdint.patch"
+      patch_description: "include <stddef>"
+      patch_type: "portability"
+      patch_source: "https://github.com/pistacheio/pistache/pull/1142"
+  "cci.20201127":
+    - patch_file: "patches/cci.20201127-0001-remove-fpic.patch"
+      patch_description: "disable fPIC"
+      patch_type: "conan"
+    - patch_file: "patches/cci.20201127-0002-include-stddef.patch"
+      patch_description: "include <stddef>"
+      patch_type: "portability"
+      patch_source: "https://github.com/pistacheio/pistache/pull/965"
+    - patch_file: "patches/cci.20201127-0003-include-cstdint.patch"
+      patch_description: "include <stddef>"
+      patch_type: "portability"
+      patch_source: "https://github.com/pistacheio/pistache/pull/1142"

--- a/3rd_party/pistache/conanfile.py
+++ b/3rd_party/pistache/conanfile.py
@@ -1,0 +1,179 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.files import apply_conandata_patches, export_conandata_patches, get, copy, rm, rmdir, replace_in_file, collect_libs
+from conan.tools.build import check_min_cppstd
+from conan.tools.apple import fix_apple_shared_install_name
+from conan.tools.scm import Version
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.env import VirtualBuildEnv
+from conan.tools.meson import Meson, MesonToolchain
+from conan.tools.layout import basic_layout
+from conan.tools.gnu import PkgConfigDeps
+
+import os
+
+required_conan_version = ">=1.53.0"
+
+class PistacheConan(ConanFile):
+    name = "pistache"
+    description = "Pistache is a modern and elegant HTTP and REST framework for C++"
+    license = "Apache-2.0"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/pistacheio/pistache"
+    topics = ("http", "rest", "framework", "networking")
+    package_type = "library"
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "with_ssl": [True, False],
+    }
+    default_options = {
+        "shared": False,
+        "fPIC": True,
+        "with_ssl": False,
+    }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "6",
+        }
+
+    def export_sources(self):
+        export_conandata_patches(self)
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def layout(self):
+        if self.version == "cci.20201127":
+            cmake_layout(self, src_folder="src")
+        else:
+            basic_layout(self, src_folder="src")
+
+    def requirements(self):
+        self.requires("rapidjson/cci.20230929")
+        if self.options.with_ssl:
+            self.requires("openssl/[>=1.1 <4]")
+        if self.version != "cci.20201127":
+            self.requires("date/3.0.1")
+
+    def validate(self):
+        if self.settings.os != "Linux":
+            raise ConanInvalidConfiguration(f"{self.ref} is only support on Linux.")
+
+        if self.settings.compiler == "clang" and self.version in ["cci.20201127", "0.0.5"]:
+            raise ConanInvalidConfiguration(f"{self.ref}'s clang support is broken. See pistacheio/pistache#835.")
+
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(
+                f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support."
+            )
+
+    def build_requirements(self):
+        if self.version != "cci.20201127":
+            self.tool_requires("meson/1.3.1")
+            if not self.conf.get("tools.gnu:pkg_config", default=False, check_type=str):
+                self.tool_requires("pkgconf/2.1.0")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def generate(self):
+        if self.version == "cci.20201127":
+            tc = CMakeToolchain(self)
+            tc.variables["PISTACHE_ENABLE_NETWORK_TESTS"] = False
+            tc.variables["PISTACHE_USE_SSL"] = self.options.with_ssl
+            # pistache requires explicit value for fPIC
+            tc.variables["CMAKE_POSITION_INDEPENDENT_CODE"] = self.options.get_safe("fPIC", True)
+            tc.generate()
+
+            tc = CMakeDeps(self)
+            tc.generate()
+        else:
+            tc = MesonToolchain(self)
+            tc.project_options["PISTACHE_USE_SSL"] = self.options.with_ssl
+            tc.project_options["PISTACHE_BUILD_EXAMPLES"] = False
+            tc.project_options["PISTACHE_BUILD_TESTS"] = False
+            tc.project_options["PISTACHE_BUILD_DOCS"] = False
+            tc.generate()
+
+            tc = PkgConfigDeps(self)
+            tc.generate()
+
+            env = VirtualBuildEnv(self)
+            env.generate(scope="build")
+
+    def build(self):
+        apply_conandata_patches(self)
+        if self.version != "cci.20201127":
+            replace_in_file(self, os.path.join(self.source_folder, "meson.build"),
+                                    "dependency('RapidJSON', fallback: ['rapidjson', 'rapidjson_dep'])",
+                                    "dependency('rapidjson', fallback: ['rapidjson', 'rapidjson_dep'])")
+
+        if self.version == "cci.20201127":
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+        else:
+            meson = Meson(self)
+            meson.configure()
+            meson.build()
+
+    def package(self):
+        copy(self, pattern="LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
+        if self.version == "cci.20201127":
+            cmake = CMake(self)
+            cmake.install()
+        else:
+            meson = Meson(self)
+            meson.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+        rmdir(self, os.path.join(self.package_folder, "lib", "pkgconfig"))
+        if self.options.shared:
+            rm(self, "*.a", os.path.join(self.package_folder, "lib"))
+        fix_apple_shared_install_name(self)
+
+    def package_info(self):
+        # TODO: Pistache does not use namespace
+        # TODO: Pistache variables are CamelCase e.g Pistache_BUILD_DIRS
+        self.cpp_info.set_property("cmake_file_name", "Pistache")
+        self.cpp_info.set_property("cmake_target_name", "Pistache::Pistache")
+        # if package provides a pkgconfig file (package.pc, usually installed in <prefix>/lib/pkgconfig/)
+        self.cpp_info.set_property("pkg_config_name", "libpistache")
+
+        self.cpp_info.components["libpistache"].libs = collect_libs(self)
+        self.cpp_info.components["libpistache"].requires = ["rapidjson::rapidjson"]
+        if self.version != "cci.20201127":
+            self.cpp_info.components["libpistache"].requires.append("date::date")
+        if self.options.with_ssl:
+            self.cpp_info.components["libpistache"].requires.append("openssl::openssl")
+            self.cpp_info.components["libpistache"].defines = ["PISTACHE_USE_SSL=1"]
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.components["libpistache"].system_libs = ["pthread"]
+            if self.version != "cci.20201127":
+                self.cpp_info.components["libpistache"].system_libs.append("m")
+
+        # TODO: to remove in conan v2 once cmake_find_package_* generators removed
+        self.cpp_info.filenames["cmake_find_package"] = "Pistache"
+        self.cpp_info.filenames["cmake_find_package_multi"] = "Pistache"
+        self.cpp_info.names["cmake_find_package"] = "Pistache"
+        self.cpp_info.names["cmake_find_package_multi"] = "Pistache"
+        self.cpp_info.names["pkg_config"] = "libpistache"
+        suffix = "_{}".format("shared" if self.options.shared else "static")
+        self.cpp_info.components["libpistache"].names["cmake_find_package"] = "pistache" + suffix
+        self.cpp_info.components["libpistache"].names["cmake_find_package_multi"] = "pistache" + suffix

--- a/3rd_party/pistache/patches/0.0.5-0001-include-cstdint.patch
+++ b/3rd_party/pistache/patches/0.0.5-0001-include-cstdint.patch
@@ -1,0 +1,13 @@
+diff --git a/include/pistache/flags.h b/include/pistache/flags.h
+index 9be2b32..ed37150 100644
+--- a/include/pistache/flags.h
++++ b/include/pistache/flags.h
+@@ -11,7 +11,7 @@
+ */
+ 
+ #pragma once
+-
++#include <cstdint>
+ #include <climits>
+ #include <iostream>
+ #include <type_traits>

--- a/3rd_party/pistache/patches/0.0.5-0002-disable-older-tls.patch
+++ b/3rd_party/pistache/patches/0.0.5-0002-disable-older-tls.patch
@@ -1,0 +1,28 @@
+diff -Naur a/src/server/listener.cc b/src/server/listener.cc
+--- a/src/server/listener.cc	2022-09-02 13:59:00.000000000 -0700
++++ b/src/server/listener.cc	2024-10-10 11:00:05.512069049 -0700
+@@ -105,6 +105,24 @@
+                     throw std::runtime_error(err);
+                 }
+             }
++            if (!SSL_CTX_set_options(GetSSLContext(ctx), SSL_OP_NO_SSLv3))
++            {
++                std::string err = "SSL error - cannot disable SSLv3: "
++                    + ssl_print_errors_to_string();
++                throw std::runtime_error(err);
++            }
++            if (!SSL_CTX_set_options(GetSSLContext(ctx), SSL_OP_NO_TLSv1))
++            {
++                std::string err = "SSL error - cannot disable TLSv1.0: "
++                    + ssl_print_errors_to_string();
++                throw std::runtime_error(err);
++            }
++            if (!SSL_CTX_set_options(GetSSLContext(ctx), SSL_OP_NO_TLSv1_1))
++            {
++                std::string err = "SSL error - cannot disable TLSv1.1: "
++                    + ssl_print_errors_to_string();
++                throw std::runtime_error(err);
++            }
+ 
+             if (cb != NULL)
+             {

--- a/3rd_party/pistache/patches/cci.20201127-0001-remove-fpic.patch
+++ b/3rd_party/pistache/patches/cci.20201127-0001-remove-fpic.patch
@@ -1,0 +1,12 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 9cdac6b..b2d13b4 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -12,7 +12,6 @@ set(SOURCE_FILES
+ )
+ 
+ add_library(pistache OBJECT ${SOURCE_FILES})
+-set_target_properties(pistache PROPERTIES POSITION_INDEPENDENT_CODE 1)
+ add_definitions(-DONLY_C_LOCALE=1)
+ 
+ set(PISTACHE_INCLUDE

--- a/3rd_party/pistache/patches/cci.20201127-0002-include-stddef.patch
+++ b/3rd_party/pistache/patches/cci.20201127-0002-include-stddef.patch
@@ -1,0 +1,12 @@
+fixed upstream https://github.com/pistacheio/pistache/pull/965
+
+--- a/include/pistache/typeid.h
++++ b/include/pistache/typeid.h
+@@ -11,6 +11,7 @@
+ 
+ #pragma once
+ 
++#include <cstddef>
+ #include <functional>
+ 
+ namespace Pistache {

--- a/3rd_party/pistache/patches/cci.20201127-0003-include-cstdint.patch
+++ b/3rd_party/pistache/patches/cci.20201127-0003-include-cstdint.patch
@@ -1,0 +1,13 @@
+diff --git a/include/pistache/flags.h b/include/pistache/flags.h
+index 2538773..fcd0252 100644
+--- a/include/pistache/flags.h
++++ b/include/pistache/flags.h
+@@ -5,7 +5,7 @@
+ */
+ 
+ #pragma once
+-
++#include <cstdint>
+ #include <climits>
+ #include <iostream>
+ #include <type_traits>

--- a/3rd_party/pistache/test_package/CMakeLists.txt
+++ b/3rd_party/pistache/test_package/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package LANGUAGES CXX)
+
+find_package(Pistache REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE Pistache::Pistache)
+if(Pistache_VERSION EQUAL "cci.20201127")
+  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+else()
+  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+endif()

--- a/3rd_party/pistache/test_package/conanfile.py
+++ b/3rd_party/pistache/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindirs[0], "test_package")
+            self.run(bin_path, env="conanrun")

--- a/3rd_party/pistache/test_package/test_package.cpp
+++ b/3rd_party/pistache/test_package/test_package.cpp
@@ -1,0 +1,27 @@
+#include "pistache/endpoint.h"
+
+using namespace Pistache;
+
+class HelloHandler : public Http::Handler {
+public:
+
+    HTTP_PROTOTYPE(HelloHandler)
+
+    void onRequest(const Http::Request& request, Http::ResponseWriter response) override{
+        response.send(Pistache::Http::Code::Ok, "Hello World\n");
+    }
+};
+
+int main() {
+    Pistache::Address addr(Pistache::Ipv4::any(), Pistache::Port(9080));
+    auto opts = Pistache::Http::Endpoint::options()
+        .threads(1);
+
+    Http::Endpoint server(addr);
+    server.init(opts);
+    server.setHandler(Http::make_handler<HelloHandler>());
+    server.serveThreaded();
+    server.shutdown();
+
+	return 0;
+}

--- a/3rd_party/pistache/test_v1_package/CMakeLists.txt
+++ b/3rd_party/pistache/test_v1_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+project(test_package)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup(TARGETS)
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../test_package/
+                 ${CMAKE_CURRENT_BINARY_DIR}/test_package/)

--- a/3rd_party/pistache/test_v1_package/conanfile.py
+++ b/3rd_party/pistache/test_v1_package/conanfile.py
@@ -1,0 +1,18 @@
+from conans import ConanFile, CMake
+from conan.tools.build import cross_building
+import os
+
+
+class TestPackageV1Conan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "cmake", "cmake_find_package_multi"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if not cross_building(self):
+            bin_path = os.path.join("bin", "test_package")
+            self.run(bin_path, run_environment=True)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A C++23 library of high-performance data structures, utilities, and infrastructu
   - [Utility](#utility)
   - [Sobject](#sobject)
   - [File Watcher](#file-watcher)
+  - [HTTP Server](#http-server)
 - [Platform Support](#platform-support)
 - [Contributing](#contributing)
 - [License](#license)
@@ -54,6 +55,7 @@ conan build -s:h build_type=Debug --build missing .
 |--------|---------|-------------|
 | `metrics` | `True` | Metrics, WISR, FDS, Cache, and Settings components |
 | `grpc` | `True` | gRPC transport and Flip fault injection (requires `metrics`) |
+| `http` | `True` | HTTP server component built on Pistache (Linux only) |
 | `malloc_impl` | `libc` | Memory allocator: `libc`, `tcmalloc`, or `jemalloc` |
 | `sanitize` | `False` | Enable sanitizer: `address` (AddressSanitizer + UBSan) or `thread` (ThreadSanitizer) |
 | `coverage` | `False` | Enable gcov code coverage |
@@ -376,6 +378,36 @@ watcher.register_listener("/etc/myapp/config.json", "cfg-reload",
     [](const std::string& path, bool deleted) {
         if (!deleted) Settings::instance().reload(path);
     });
+```
+
+### HTTP Server
+
+A Pistache-based HTTP server with middleware auth, SSL support, and per-route access control (Linux only). Routes are classified as `localhost` (local callers only), `safe` (no auth), or `regular` (subject to token verification).
+
+```cpp
+sisl::HttpServer server{5000, /*threads=*/4, /*max_request_size=*/4000000, token_verifier};
+
+server.setup_routes({
+    {Pistache::Http::Method::Get,  "/status", handle_status, sisl::url_type::safe},
+    {Pistache::Http::Method::Post, "/config", handle_config, sisl::url_type::regular},
+});
+
+// When compiled with metrics=True, wire up /metrics scrape automatically:
+server.register_metrics_endpoint();
+
+server.start();
+// ...
+server.stop();
+```
+
+SSL can be enabled at construction or hot-swapped at runtime:
+
+```cpp
+// SSL from the start:
+sisl::HttpServer secure{ssl_cert, ssl_key, 5443, 4, 4000000, token_verifier};
+
+// Hot-swap certs without dropping the port:
+server.restart(new_cert, new_key);
 ```
 
 ---

--- a/conanfile.py
+++ b/conanfile.py
@@ -26,6 +26,7 @@ class SISLConan(ConanFile):
                 "sanitize": ['address', 'thread', 'False'],
                 'metrics': ['False', 'True'],
                 'grpc': ['False', 'True'],
+                'http': ['False', 'True'],
                 'malloc_impl' : ['libc', 'tcmalloc', 'jemalloc'],
               }
     default_options = {
@@ -35,6 +36,7 @@ class SISLConan(ConanFile):
                 'sanitize': False,
                 'metrics': True,
                 'grpc': True,
+                'http': True,
                 'malloc_impl': 'libc',
             }
 
@@ -58,8 +60,9 @@ class SISLConan(ConanFile):
         if not self.options.metrics and self.options.grpc:
             raise ConanInvalidConfiguration("gRPC support requires metrics option!")
 
-        if self.settings.compiler in ["gcc"]:
-            self.options['pistache'].with_ssl: True
+        if self.options.http:
+            if self.settings.os not in ["Linux"]:
+                raise ConanInvalidConfiguration("http option requires Linux (Pistache constraint)")
         if self.options.shared:
             self.options.rm_safe("fPIC")
         if self.settings.build_type == "Debug":
@@ -97,6 +100,9 @@ class SISLConan(ConanFile):
 
         if self.options.grpc:
             self.requires("grpc/1.69.0", transitive_headers=True)
+
+        if self.options.http:
+            self.requires("pistache/nbi.0.0.5.1", transitive_headers=True)
 
         # Memory allocation
         if self.options.malloc_impl == "tcmalloc":
@@ -143,6 +149,10 @@ class SISLConan(ConanFile):
             self.cpp.build.components["flip"].includedirs = ["src/flip"]
             self.cpp.build.components["flip"].libdirs = ["src/flip"]
             self.cpp.package.components["flip"].libs = ["flip"]
+
+        if self.options.http:
+            self.cpp.build.components["http"].libdirs = ["src/http"]
+            self.cpp.package.components["http"].libs = ["sisl_http"]
 
         self.cpp.package.includedirs = ["include"] # includedirs is already set to 'include' by
         self.cpp.package.libdirs = ["lib"]
@@ -279,6 +289,12 @@ class SISLConan(ConanFile):
                     ])
             self.cpp_info.components["sisl"].requires.extend([
                     "grpc",
+                    ])
+
+        if self.options.http:
+            self.cpp_info.components["http"].requires.extend([
+                    "logging",
+                    "pistache::pistache",
                     ])
 
         for component in self.cpp_info.components.values():

--- a/include/sisl/http/http_server.hpp
+++ b/include/sisl/http/http_server.hpp
@@ -1,0 +1,98 @@
+/*********************************************************************************
+ * Modifications Copyright 2026 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+#pragma once
+
+#include <atomic>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <pistache/endpoint.h>
+#include <pistache/http.h>
+#include <pistache/http_headers.h>
+#include <pistache/router.h>
+
+#include <sisl/auth_manager/token_verifier.hpp>
+#include <sisl/utility/enum.hpp>
+
+namespace sisl {
+
+ENUM(url_type, uint8_t,
+     localhost, // url can only be called from localhost
+     safe,      // can be called from any host without auth
+     regular);  // subject to normal auth rules
+
+struct http_route {
+    Pistache::Http::Method method;
+    std::string resource;
+    Pistache::Rest::Route::Handler handler;
+    sisl::url_type type{sisl::url_type::regular};
+};
+
+class HttpServer {
+public:
+    explicit HttpServer(uint16_t port = 5000, uint32_t num_threads = 1, uint64_t max_request_size = 4000000,
+                        sisl::TokenVerifier* token_verifier = nullptr);
+    HttpServer(std::string const& ssl_cert, std::string const& ssl_key, uint16_t port = 5000, uint32_t num_threads = 1,
+               uint64_t max_request_size = 4000000, sisl::TokenVerifier* token_verifier = nullptr);
+
+    // All routes must be registered before start()
+    void setup_route(Pistache::Http::Method method, std::string resource, Pistache::Rest::Route::Handler handler,
+                     url_type const& type = url_type::regular);
+    void setup_routes(std::vector< http_route > const& routes);
+
+    void start();
+    void stop();
+    void restart(std::string const& ssl_cert, std::string const& ssl_key);
+    void setup_ssl(std::string const& ssl_cert, std::string const& ssl_key);
+
+#ifdef PROMETHEUS_METRICS_REPORTER
+    // Registers GET /metrics → MetricsFarm::report(kTextFormat). Call before start().
+    void register_metrics_endpoint();
+#endif
+
+    bool do_auth(Pistache::Http::Request& request, Pistache::Http::ResponseWriter& response);
+    bool is_localaddr_url(std::string const& url) const;
+    bool is_safe_url(std::string const& url) const;
+    bool is_secure_zone() const;
+    bool auth_verify(Pistache::Http::Request& request, Pistache::Http::ResponseWriter& response) const;
+
+private:
+    void init();
+    void get_local_ips();
+    bool is_local_addr(std::string const& addr) const;
+    void setup_route(http_route const& route, bool restart);
+
+private:
+    uint16_t m_port;
+    uint32_t m_num_threads;
+    uint64_t m_max_request_size;
+    sisl::TokenVerifier* m_token_verifier;
+    std::string m_ssl_cert;
+    std::string m_ssl_key;
+    bool m_secure_zone{false};
+
+    std::unique_ptr< Pistache::Http::Endpoint > m_http_endpoint;
+    Pistache::Rest::Router m_router;
+    std::atomic< bool > m_server_running{false};
+    std::unordered_set< std::string > m_safelist;
+    std::unordered_set< std::string > m_localhost_list;
+    std::unordered_set< std::string > m_local_ips;
+    std::vector< http_route > m_http_routes;
+    std::mutex m_mutex;
+};
+
+} // namespace sisl

--- a/prepare_v2.sh
+++ b/prepare_v2.sh
@@ -3,4 +3,6 @@ set -eu
 echo -n "Exporting custom recipes..."
 echo -n "userspace rcu."
 conan export 3rd_party/userspace-rcu --name userspace-rcu --version nu2.0.14.0 >/dev/null
-echo "done."
+echo -n " pistache."
+conan export 3rd_party/pistache --name pistache --version nbi.0.0.5.1 >/dev/null
+echo " done."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,3 +41,8 @@ if (${flatbuffers_FOUND})
     add_subdirectory(grpc)
   endif()
 endif()
+
+find_package(Pistache QUIET)
+if(${Pistache_FOUND})
+  add_subdirectory(http)
+endif()

--- a/src/cache/CMakeLists.txt
+++ b/src/cache/CMakeLists.txt
@@ -15,9 +15,6 @@ target_sources(test_range_hashmap PRIVATE
 target_include_directories(test_range_hashmap BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(test_range_hashmap sisl_cache GTest::gtest)
 add_test(NAME RangeHashMap COMMAND test_range_hashmap --num_iters 10000 -v warn)
-if ((DEFINED ADDRESS_SANITIZER_ON AND ADDRESS_SANITIZER_ON) OR (DEFINED THREAD_SANITIZER_ON AND THREAD_SANITIZER_ON))
-  set_tests_properties(RangeHashMap PROPERTIES DISABLED TRUE)
-endif()
 
 add_executable(test_range_cache)
 target_sources(test_range_cache PRIVATE

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.11)
+
+find_package(Pistache REQUIRED)
+
+add_library(sisl_http)
+target_sources(sisl_http PRIVATE
+  http_server.cpp
+  )
+target_link_libraries(sisl_http PUBLIC
+  sisl_logging
+  Pistache::Pistache
+  )
+
+add_executable(test_http_server)
+target_sources(test_http_server PRIVATE
+  tests/test_http_server.cpp
+  )
+target_link_libraries(test_http_server sisl_http sisl_options GTest::gtest)
+add_test(NAME HttpServer COMMAND test_http_server -v warn)

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -1,0 +1,205 @@
+#include <chrono>
+#include <filesystem>
+#include <thread>
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+
+#include <sisl/http/http_server.hpp>
+#include <sisl/logging/logging.h>
+
+#ifdef PROMETHEUS_METRICS_REPORTER
+#include <sisl/metrics/metrics.hpp>
+#endif
+
+SISL_LOGGING_DECL(http)
+
+namespace sisl {
+
+static Pistache::Http::Code to_pistache_code(sisl::token_state_ptr const status) {
+    switch (status->code) {
+    case sisl::VerifyCode::OK:
+        return Pistache::Http::Code::Ok;
+    case sisl::VerifyCode::UNAUTH:
+        return Pistache::Http::Code::Unauthorized;
+    case sisl::VerifyCode::FORBIDDEN:
+        return Pistache::Http::Code::Forbidden;
+    default:
+        break;
+    }
+    return Pistache::Http::Code::Precondition_Failed;
+}
+
+HttpServer::HttpServer(uint16_t port, uint32_t num_threads, uint64_t max_request_size,
+                       sisl::TokenVerifier* token_verifier) :
+        m_port{port},
+        m_num_threads{num_threads},
+        m_max_request_size{max_request_size},
+        m_token_verifier{token_verifier} {
+    init();
+    get_local_ips();
+}
+
+HttpServer::HttpServer(std::string const& ssl_cert, std::string const& ssl_key, uint16_t port, uint32_t num_threads,
+                       uint64_t max_request_size, sisl::TokenVerifier* token_verifier) :
+        m_port{port},
+        m_num_threads{num_threads},
+        m_max_request_size{max_request_size},
+        m_token_verifier{token_verifier},
+        m_ssl_cert{ssl_cert},
+        m_ssl_key{ssl_key},
+        m_secure_zone{!ssl_cert.empty() && !ssl_key.empty()} {
+    if (!m_secure_zone && (!ssl_cert.empty() || !ssl_key.empty())) {
+        LOGERROR("one of ssl_cert {}, ssl_key: {} is empty!", ssl_cert, ssl_key);
+        return;
+    }
+    init();
+    get_local_ips();
+}
+
+void HttpServer::init() {
+    m_http_endpoint.reset();
+    Pistache::Address addr(Pistache::Ipv4::any(), Pistache::Port(m_port));
+    m_http_endpoint = std::make_unique< Pistache::Http::Endpoint >(addr);
+    auto flags = Pistache::Tcp::Options::ReuseAddr;
+    auto opts = Pistache::Http::Endpoint::options()
+                    .threadsName("http_server")
+                    .maxRequestSize(m_max_request_size)
+                    .threads(m_num_threads)
+                    .flags(flags);
+    m_http_endpoint->init(opts);
+    setup_ssl(m_ssl_cert, m_ssl_key);
+}
+
+void HttpServer::start() {
+    m_router.addMiddleware(Pistache::Rest::Routes::middleware(&HttpServer::do_auth, this));
+    m_http_endpoint->setHandler(m_router.handler());
+    m_http_endpoint->serveThreaded();
+    m_server_running = true;
+}
+
+void HttpServer::stop() {
+    m_http_endpoint->shutdown();
+    m_server_running = false;
+}
+
+void HttpServer::restart(std::string const& ssl_cert, std::string const& ssl_key) {
+    std::unique_lock< std::mutex > lock(m_mutex);
+    m_server_running = false;
+    m_ssl_cert = ssl_cert;
+    m_ssl_key = ssl_key;
+    m_secure_zone = !ssl_cert.empty() && !ssl_key.empty();
+    init();
+    m_localhost_list.clear();
+    m_safelist.clear();
+    m_router = Pistache::Rest::Router();
+    for (auto& route : m_http_routes) {
+        setup_route(route, true);
+    }
+    start();
+}
+
+void HttpServer::setup_route(Pistache::Http::Method method, std::string resource,
+                             Pistache::Rest::Route::Handler handler, url_type const& type) {
+    DEBUG_ASSERT(!m_server_running, "Initiated route setup after server started");
+    if (m_server_running) {
+        LOGWARN("Could not setup route {}, server is in running state.", resource)
+        return;
+    }
+
+    m_router.addRoute(std::move(method), resource, std::move(handler));
+
+    if (type == url_type::localhost) {
+        m_localhost_list.emplace(std::move(resource));
+    } else if (type == url_type::safe) {
+        m_safelist.emplace(std::move(resource));
+    }
+}
+
+void HttpServer::setup_route(http_route const& route, bool restart) {
+    if (!restart) { m_http_routes.push_back(route); }
+    setup_route(route.method, route.resource, route.handler, route.type);
+}
+
+void HttpServer::setup_routes(std::vector< http_route > const& routes) {
+    for (auto& route : routes) {
+        setup_route(route, false);
+    }
+}
+
+void HttpServer::setup_ssl(std::string const& ssl_cert, std::string const& ssl_key) {
+    if (m_secure_zone) {
+        namespace fs = std::filesystem;
+        auto wait_for_file = [](std::string const& path) {
+            while (true) {
+                if (fs::exists(path) && fs::file_size(fs::path{path}) > 0) { return; }
+                LOGINFO("File {} not available, will try in 5 seconds", path);
+                std::this_thread::sleep_for(std::chrono::seconds(5));
+            }
+        };
+        wait_for_file(ssl_cert);
+        wait_for_file(ssl_key);
+#ifdef PISTACHE_USE_SSL
+        m_http_endpoint->useSSL(ssl_cert, ssl_key);
+#else
+        LOGWARN("SSL requested but Pistache was built without SSL support; ignoring certs");
+#endif
+    }
+}
+
+bool HttpServer::do_auth(Pistache::Http::Request& request, Pistache::Http::ResponseWriter& response) {
+    if (is_safe_url(request.resource())) { return true; }
+    if (is_localaddr_url(request.resource())) { return is_local_addr(request.address().host()); }
+    if (m_token_verifier) { return auth_verify(request, response); }
+    return true;
+}
+
+bool HttpServer::auth_verify(Pistache::Http::Request& request, Pistache::Http::ResponseWriter& response) const {
+    auto opt_token = request.headers().tryGet< Pistache::Http::Header::Authorization >();
+    if (!opt_token) {
+        response.send(Pistache::Http::Code::Unauthorized, "missing auth token in request header");
+        return false;
+    }
+
+    if (!opt_token->hasMethod< Pistache::Http::Header::Authorization::Method::Bearer >()) {
+        response.send(Pistache::Http::Code::Unauthorized, "require bearer token in request header");
+        return false;
+    }
+
+    auto const prefix_len = std::string{"Bearer "}.length();
+    auto ret_state = m_token_verifier->verify(opt_token->value().substr(prefix_len));
+    if (ret_state->code == sisl::VerifyCode::OK) { return true; }
+    response.send(to_pistache_code(ret_state), ret_state->msg);
+    return false;
+}
+
+void HttpServer::get_local_ips() {
+    struct ifaddrs* interfaces = nullptr;
+    auto error = getifaddrs(&interfaces);
+    if (error != 0) { LOGWARN("getifaddrs returned non zero code: {}", error); }
+    for (auto* addr = interfaces; addr != nullptr; addr = addr->ifa_next) {
+        if (addr->ifa_addr->sa_family == AF_INET) {
+            m_local_ips.emplace(inet_ntoa(((struct sockaddr_in*)addr->ifa_addr)->sin_addr));
+        }
+    }
+    freeifaddrs(interfaces);
+}
+
+bool HttpServer::is_localaddr_url(std::string const& url) const { return m_localhost_list.count(url) > 0; }
+bool HttpServer::is_safe_url(std::string const& url) const { return m_safelist.count(url) > 0; }
+bool HttpServer::is_secure_zone() const { return m_secure_zone; }
+bool HttpServer::is_local_addr(std::string const& addr) const { return m_local_ips.count(addr) > 0; }
+
+#ifdef PROMETHEUS_METRICS_REPORTER
+void HttpServer::register_metrics_endpoint() {
+    setup_route(
+        Pistache::Http::Method::Get, "/metrics",
+        [](Pistache::Http::Request const&, Pistache::Http::ResponseWriter response) {
+            response.send(Pistache::Http::Code::Ok,
+                          sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::kTextFormat));
+        },
+        url_type::safe);
+}
+#endif
+
+} // namespace sisl

--- a/src/http/tests/test_http_server.cpp
+++ b/src/http/tests/test_http_server.cpp
@@ -1,0 +1,209 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <sisl/auth_manager/token_verifier.hpp>
+#include <sisl/http/http_server.hpp>
+#include <sisl/logging/logging.h>
+#include <sisl/options/options.h>
+
+SISL_LOGGING_INIT(http)
+SISL_OPTIONS_ENABLE(logging)
+
+namespace {
+
+static std::atomic< uint16_t > s_next_port{18080};
+uint16_t next_port() { return s_next_port.fetch_add(1); }
+
+// Sends a raw HTTP/1.1 GET and returns the full response.
+std::string http_get(uint16_t port, std::string const& path, std::string const& auth_header = "") {
+    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0) return {};
+
+    struct sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+    if (::connect(sock, reinterpret_cast< struct sockaddr* >(&addr), sizeof(addr)) != 0) {
+        ::close(sock);
+        return {};
+    }
+
+    struct timeval tv{2, 0};
+    ::setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    std::string req = "GET " + path + " HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n";
+    if (!auth_header.empty()) { req += "Authorization: " + auth_header + "\r\n"; }
+    req += "\r\n";
+    ::send(sock, req.c_str(), req.size(), 0);
+
+    std::string response;
+    char buf[4096];
+    ssize_t n;
+    while ((n = ::recv(sock, buf, sizeof(buf) - 1, 0)) > 0) {
+        buf[n] = '\0';
+        response += buf;
+    }
+    ::close(sock);
+    return response;
+}
+
+int parse_status(std::string const& response) {
+    auto pos = response.find(' ');
+    if (pos == std::string::npos) return 0;
+    try {
+        return std::stoi(response.substr(pos + 1, 3));
+    } catch (...) { return 0; }
+}
+
+bool wait_for_server(uint16_t port, int attempts = 40) {
+    for (int i = 0; i < attempts; ++i) {
+        int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+        struct sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(port);
+        ::inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+        bool ok = ::connect(sock, reinterpret_cast< struct sockaddr* >(&addr), sizeof(addr)) == 0;
+        ::close(sock);
+        if (ok) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return false;
+}
+
+// Accepts "valid-token", rejects everything else.
+class MockVerifier : public sisl::TokenVerifier {
+public:
+    sisl::token_state_ptr verify(std::string const& token) const override {
+        if (token == "valid-token") { return std::make_shared< sisl::TokenVerifyState >(sisl::VerifyCode::OK, ""); }
+        return std::make_shared< sisl::TokenVerifyState >(sisl::VerifyCode::UNAUTH, "invalid token");
+    }
+};
+
+Pistache::Rest::Route::Result ok_handler(Pistache::Rest::Request const&, Pistache::Http::ResponseWriter resp) {
+    resp.send(Pistache::Http::Code::Ok, "ok");
+    return Pistache::Rest::Route::Result::Ok;
+}
+
+} // namespace
+
+// ---- URL classification (no server start needed) ----
+
+TEST(HttpServer, UrlClassification) {
+    sisl::HttpServer server{next_port()};
+    server.setup_route(Pistache::Http::Method::Get, "/safe", ok_handler, sisl::url_type::safe);
+    server.setup_route(Pistache::Http::Method::Get, "/local", ok_handler, sisl::url_type::localhost);
+    server.setup_route(Pistache::Http::Method::Get, "/regular", ok_handler, sisl::url_type::regular);
+
+    EXPECT_TRUE(server.is_safe_url("/safe"));
+    EXPECT_FALSE(server.is_safe_url("/local"));
+    EXPECT_FALSE(server.is_safe_url("/regular"));
+
+    EXPECT_TRUE(server.is_localaddr_url("/local"));
+    EXPECT_FALSE(server.is_localaddr_url("/safe"));
+    EXPECT_FALSE(server.is_localaddr_url("/regular"));
+}
+
+TEST(HttpServer, SecureZoneFlag) {
+    sisl::HttpServer plain{next_port()};
+    EXPECT_FALSE(plain.is_secure_zone());
+
+    // SSL constructor with empty strings → not secure (one-but-not-both check logs an error)
+    sisl::HttpServer also_plain{"", "", next_port()};
+    EXPECT_FALSE(also_plain.is_secure_zone());
+}
+
+// ---- Live HTTP tests ----
+
+TEST(HttpServer, SafeRouteReturns200) {
+    uint16_t port = next_port();
+    sisl::HttpServer server{port};
+    server.setup_route(Pistache::Http::Method::Get, "/health", ok_handler, sisl::url_type::safe);
+    server.start();
+    ASSERT_TRUE(wait_for_server(port));
+
+    EXPECT_EQ(parse_status(http_get(port, "/health")), 200);
+
+    server.stop();
+}
+
+TEST(HttpServer, RegularRouteNoVerifierReturns200) {
+    uint16_t port = next_port();
+    sisl::HttpServer server{port};
+    server.setup_route(Pistache::Http::Method::Get, "/data", ok_handler, sisl::url_type::regular);
+    server.start();
+    ASSERT_TRUE(wait_for_server(port));
+
+    EXPECT_EQ(parse_status(http_get(port, "/data")), 200);
+
+    server.stop();
+}
+
+TEST(HttpServer, LocalhostRouteFromLoopbackReturns200) {
+    uint16_t port = next_port();
+    sisl::HttpServer server{port};
+    server.setup_route(Pistache::Http::Method::Get, "/local", ok_handler, sisl::url_type::localhost);
+    server.start();
+    ASSERT_TRUE(wait_for_server(port));
+
+    // Connecting from 127.0.0.1, which is in m_local_ips
+    EXPECT_EQ(parse_status(http_get(port, "/local")), 200);
+
+    server.stop();
+}
+
+TEST(HttpServer, RegularRouteNoTokenReturns401) {
+    uint16_t port = next_port();
+    MockVerifier verifier;
+    sisl::HttpServer server{port, 1, 4000000, &verifier};
+    server.setup_route(Pistache::Http::Method::Get, "/secure", ok_handler, sisl::url_type::regular);
+    server.start();
+    ASSERT_TRUE(wait_for_server(port));
+
+    EXPECT_EQ(parse_status(http_get(port, "/secure")), 401);
+
+    server.stop();
+}
+
+TEST(HttpServer, RegularRouteValidTokenReturns200) {
+    uint16_t port = next_port();
+    MockVerifier verifier;
+    sisl::HttpServer server{port, 1, 4000000, &verifier};
+    server.setup_route(Pistache::Http::Method::Get, "/secure", ok_handler, sisl::url_type::regular);
+    server.start();
+    ASSERT_TRUE(wait_for_server(port));
+
+    EXPECT_EQ(parse_status(http_get(port, "/secure", "Bearer valid-token")), 200);
+
+    server.stop();
+}
+
+TEST(HttpServer, RegularRouteInvalidTokenReturns401) {
+    uint16_t port = next_port();
+    MockVerifier verifier;
+    sisl::HttpServer server{port, 1, 4000000, &verifier};
+    server.setup_route(Pistache::Http::Method::Get, "/secure", ok_handler, sisl::url_type::regular);
+    server.start();
+    ASSERT_TRUE(wait_for_server(port));
+
+    EXPECT_EQ(parse_status(http_get(port, "/secure", "Bearer wrong-token")), 401);
+
+    server.stop();
+}
+
+int main(int argc, char* argv[]) {
+    SISL_OPTIONS_LOAD(argc, argv, logging);
+    sisl::logging::SetLogger("test_http_server");
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Extracts iomanager's Pistache-based HTTP server into sisl as a standalone, Linux-only component gated by http=True (default on).

Config is injected via constructor parameters (port, threads, max_request_size, token_verifier) rather than iomanager's settings singleton, making it usable without iomanager. Routes are classified as localhost (local callers only), safe (no auth), or regular (token verification when a TokenVerifier is provided). SSL certs can be supplied at construction or hot-swapped via restart().

Includes register_metrics_endpoint() (PROMETHEUS_METRICS_REPORTER guard) to wire GET /metrics directly to MetricsFarm.