### PR TITLE
http: enable register_metrics_endpoint() when sisl_metrics is available

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -296,6 +296,9 @@ class SISLConan(ConanFile):
                     "logging",
                     "pistache::pistache",
                     ])
+            if self.options.metrics:
+                self.cpp_info.components["http"].requires.append("metrics")
+                self.cpp_info.components["http"].defines.append("PROMETHEUS_METRICS_REPORTER")
 
         for component in self.cpp_info.components.values():
             if self.settings.os in ["Linux", "FreeBSD"]:

--- a/src/http/CMakeLists.txt
+++ b/src/http/CMakeLists.txt
@@ -11,6 +11,11 @@ target_link_libraries(sisl_http PUBLIC
   Pistache::Pistache
   )
 
+if(TARGET sisl_metrics)
+  target_link_libraries(sisl_http PUBLIC sisl_metrics)
+  target_compile_definitions(sisl_http PUBLIC PROMETHEUS_METRICS_REPORTER)
+endif()
+
 add_executable(test_http_server)
 target_sources(test_http_server PRIVATE
   tests/test_http_server.cpp

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -194,9 +194,10 @@ bool HttpServer::is_local_addr(std::string const& addr) const { return m_local_i
 void HttpServer::register_metrics_endpoint() {
     setup_route(
         Pistache::Http::Method::Get, "/metrics",
-        [](Pistache::Http::Request const&, Pistache::Http::ResponseWriter response) {
+        [](Pistache::Rest::Request const&, Pistache::Http::ResponseWriter response) {
             response.send(Pistache::Http::Code::Ok,
                           sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::kTextFormat));
+            return Pistache::Rest::Route::Result::Ok;
         },
         url_type::safe);
 }


### PR DESCRIPTION
When sisl_metrics is built alongside sisl_http, wire the dependency so that PROMETHEUS_METRICS_REPORTER is defined for sisl_http and its consumers, making register_metrics_endpoint() compile and link correctly.