### PR TITLE
fix: use move_nwords bound in resize_impl to prevent heap-buffer-overflow

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=2.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "13.2.7"
+    version = "13.2.8"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/fds/bitset.hpp
+++ b/include/sisl/fds/bitset.hpp
@@ -1161,8 +1161,7 @@ private:
 
         // copy to resized
         const uint64_t move_nwords{std::min(m_s->m_words_cap - shrink_words, new_cap)};
-        std::uninitialized_copy(std::next(m_s->get_words_const(), shrink_words), m_s->end_words_const(),
-                                new_s->get_words());
+        std::uninitialized_copy_n(std::next(m_s->get_words_const(), shrink_words), move_nwords, new_s->get_words());
         if (new_cap > move_nwords) {
             // Fill in the remaining space with value passed
             std::uninitialized_fill(std::next(new_s->get_words(), move_nwords), new_s->end_words(),


### PR DESCRIPTION
Uninitialized_copy was using end_words_const() unconditionally, copying all old words into the new (potentially smaller) buffer. On shrink, this writes one or more Bitwords past the end of the allocation. move_nwords already computed the correct min(old, new_cap) bound — use it via uninitialized_copy_n.