### PR TITLE
cleanup: remove cast macros, fix enum naming, suppress duplicate-lib …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Added / updated**: boost/1.85.0, spdlog/1.17.0, nlohmann_json/3.12.0, cxxopts/3.3.1, flatbuffers/24.12.23, prometheus-cpp/1.3.0, grpc/1.69.0, gtest/1.17.0, benchmark/1.9.5
 - **Removed**: folly (all versions)
 
+[14.0.1]: https://github.com/eBay/sisl/compare/v14.0.0...dev/v14.x
 [14.0.0]: https://github.com/eBay/sisl/compare/stable/v13.x...dev/v14.x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,10 @@ if(UNIX)
     if(APPLE)
         # _POSIX_C_SOURCE hides Darwin extensions (ipv6_mreq, NI_MAXHOST, etc.); restore them
         add_flags("-D_DARWIN_C_SOURCE")
+        # Conan-generated cmake configs expand transitive absolute-path libraries at each step,
+        # so the same .a can appear more than once on the link line; ld ignores extras safely.
+        string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-no_warn_duplicate_libraries")
+        string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-no_warn_duplicate_libraries")
     endif()
 endif()
 

--- a/include/sisl/cache/lru_evictor.hpp
+++ b/include/sisl/cache/lru_evictor.hpp
@@ -84,7 +84,7 @@ private:
         void init(LRUEvictor* evictor, const uint32_t partition_num, const uint64_t max_size) {
             m_evictor = evictor;
             m_partition_num = partition_num;
-            m_max_size = int64_cast(max_size);
+            m_max_size = static_cast< int64_t >(max_size);
         }
         bool add_record(CacheRecord& record);
         void remove_record(CacheRecord& record);

--- a/include/sisl/cache/range_hashmap.hpp
+++ b/include/sisl/cache/range_hashmap.hpp
@@ -37,7 +37,7 @@ using big_offset_t = uint32_t;
 using big_count_t = uint32_t;
 using big_range_t = std::pair< big_offset_t, big_offset_t >;
 
-inline constexpr big_count_t max_n_per_node = (s_cast< uint64_t >(1) << (sizeof(small_offset_t) * 8));
+inline constexpr big_count_t max_n_per_node = (1ULL << (sizeof(small_offset_t) * 8));
 inline constexpr small_offset_t max_offset_in_node = std::numeric_limits< small_offset_t >::max();
 inline constexpr size_t s_start_seed = 0;
 
@@ -248,8 +248,8 @@ public:
         small_range_t input_range = to_relative_range(input_key);
 
         // First binary_search for the location, if there is a valid
-        auto [idx, found] = binary_search(-1, int_cast(m_values.size()), input_range.first);
-        while (idx < int_cast(m_values.size())) {
+        auto [idx, found] = binary_search(-1, static_cast< int >(m_values.size()), input_range.first);
+        while (idx < static_cast< int >(m_values.size())) {
             if (input_range.second >= m_values[idx].m_range.first) {
                 out_values.emplace_back(extract_matched_kv(m_values[idx], input_range));
                 m_values[idx].access_cb(this, hash_op_t::ACCESS);
@@ -270,8 +270,8 @@ public:
     void insert(const RangeKey< K >& input_key, sisl::byte_view&& value) {
         const small_range_t input_range = to_relative_range(input_key);
 
-        auto [l_idx, l_found] = binary_search(-1, int_cast(m_values.size()), input_range.first);
-        auto [r_idx, r_found] = binary_search(-1, int_cast(m_values.size()), input_range.second);
+        auto [l_idx, l_found] = binary_search(-1, static_cast< int >(m_values.size()), input_range.first);
+        auto [r_idx, r_found] = binary_search(-1, static_cast< int >(m_values.size()), input_range.second);
 
         bool is_move_to_left = l_found && (input_range.first > m_values[l_idx].m_range.first);
         bool is_move_to_right = r_found && (input_range.second < m_values[r_idx].m_range.second);
@@ -303,7 +303,7 @@ public:
             LOGDEBUG("Node({}) To insert: shrinking entry by moving right at idx={}, new value=[{}]", to_string(),
                      r_idx, m_values[r_idx].to_string());
         } else {
-            r_idx = std::min(r_idx + 1, int_cast(m_values.size()));
+            r_idx = std::min(r_idx + 1, static_cast< int >(m_values.size()));
         }
 
         // Erase all intermediate entries
@@ -327,8 +327,8 @@ public:
 
     small_count_t erase(const RangeKey< K >& input_key) {
         const small_range_t input_range = to_relative_range(input_key);
-        auto [l_idx, l_found] = binary_search(-1, int_cast(m_values.size()), input_range.first);
-        auto [r_idx, r_found] = binary_search(-1, int_cast(m_values.size()), input_range.second);
+        auto [l_idx, l_found] = binary_search(-1, static_cast< int >(m_values.size()), input_range.first);
+        auto [r_idx, r_found] = binary_search(-1, static_cast< int >(m_values.size()), input_range.second);
 
         bool is_move_to_left = l_found && (input_range.first > m_values[l_idx].m_range.first);
         bool is_move_to_right = r_found && (input_range.second < m_values[r_idx].m_range.second);
@@ -361,7 +361,7 @@ public:
             LOGDEBUG("Node({}) To erase: shrinking entry by moving right at idx={}, new value=[{}]", to_string(), r_idx,
                      m_values[r_idx].to_string());
         } else {
-            r_idx = std::min(r_idx + 1, int_cast(m_values.size()));
+            r_idx = std::min(r_idx + 1, static_cast< int >(m_values.size()));
         }
 
         if (r_idx > l_idx) {
@@ -375,7 +375,7 @@ public:
             m_values.erase(m_values.begin() + l_idx, m_values.begin() + r_idx);
         }
 
-        return s_cast< small_count_t >(m_values.size());
+        return static_cast< small_count_t >(m_values.size());
     }
 
     std::string to_string() const { return fmt::format("BaseKey={} Nth_Offset={}", m_base_key, m_base_nth); }
@@ -414,7 +414,8 @@ private:
     }
 
     RangeKey< K > to_big_key(const small_range_t range) const {
-        return RangeKey< K >{m_base_key, m_base_nth + range.first, uint32_cast(range.second) - range.first + 1};
+        return RangeKey< K >{m_base_key, m_base_nth + range.first,
+                             static_cast< uint32_t >(range.second) - range.first + 1};
     }
 
     std::pair< RangeKey< K >, sisl::byte_view > extract_matched_kv(const ValueEntryRange& ventry,

--- a/include/sisl/fds/buffer.hpp
+++ b/include/sisl/fds/buffer.hpp
@@ -258,11 +258,12 @@ public:
 
     T* allocate(std::size_t nelems) {
         if (nelems > std::numeric_limits< std::size_t >::max() / sizeof(T)) { throw std::bad_array_new_length(); }
-        return r_cast< T* >(AlignedAllocator::allocator().aligned_alloc(Alignment, nelems * sizeof(T), buftag::common));
+        return reinterpret_cast< T* >(
+            AlignedAllocator::allocator().aligned_alloc(Alignment, nelems * sizeof(T), buftag::common));
     }
 
     void deallocate(T* ptr, [[maybe_unused]] std::size_t nbytes) {
-        AlignedAllocator::allocator().aligned_free(uintptr_cast(ptr), buftag::common);
+        AlignedAllocator::allocator().aligned_free(reinterpret_cast< uint8_t* >(ptr), buftag::common);
     }
 };
 
@@ -373,14 +374,14 @@ public:
     bool is_aligned() const { return aligned_; }
 
     static io_blob from_string(std::string_view s) {
-        return io_blob{r_cast< const uint8_t* >(s.data()), uint32_cast(s.size()), false};
+        return io_blob{reinterpret_cast< const uint8_t* >(s.data()), static_cast< uint32_t >(s.size()), false};
     }
 
     static io_blob_list_t sg_list_to_ioblob_list(const sg_list& sglist) {
         io_blob_list_t ret_list;
         for (const auto& iov : sglist.iovs) {
-            ret_list.emplace_back(r_cast< uint8_t* >(const_cast< void* >(iov.iov_base)), uint32_cast(iov.iov_len),
-                                  false);
+            ret_list.emplace_back(reinterpret_cast< uint8_t* >(const_cast< void* >(iov.iov_base)),
+                                  static_cast< uint32_t >(iov.iov_len), false);
         }
         return ret_list;
     }
@@ -508,7 +509,9 @@ public:
                         "Invalid byte_view");
     }
 
-    std::string get_string() const { return std::string(r_cast< const char* >(bytes()), uint64_cast(size())); }
+    std::string get_string() const {
+        return std::string(reinterpret_cast< const char* >(bytes()), static_cast< uint64_t >(size()));
+    }
 
 private:
     byte_array m_base_buf;

--- a/include/sisl/fds/compact_bitset.hpp
+++ b/include/sisl/fds/compact_bitset.hpp
@@ -14,6 +14,7 @@
  * specific language governing permissions and limitations under the License.
  *
  *********************************************************************************/
+#pragma once
 #include <cstdint>
 #include <sisl/fds/bitword.hpp>
 #include <sisl/fds/utils.hpp>
@@ -46,16 +47,16 @@ public:
 
     explicit CompactBitSet(bit_count_t nbits) {
         DEBUG_ASSERT_GT(nbits, 0, "compact bitset should have nbits > 0");
-        nbits_ = s_cast< bit_count_t >(sisl::round_up(nbits, word_size_bits()));
+        nbits_ = static_cast< bit_count_t >(sisl::round_up(nbits, word_size_bits()));
         size_t const buf_size = nbits_ / 8;
 
         uint8_t* buf = new uint8_t[buf_size];
         std::memset(buf, 0, buf_size);
-        s_ = r_cast< serialized* >(buf);
+        s_ = reinterpret_cast< serialized* >(buf);
         allocated_ = true;
     }
 
-    CompactBitSet(sisl::blob buf, bool init_bits) : s_{r_cast< serialized* >(buf.bytes())} {
+    CompactBitSet(sisl::blob buf, bool init_bits) : s_{reinterpret_cast< serialized* >(buf.bytes())} {
         DEBUG_ASSERT_GT(buf.size(), 0, "compact bitset initialized with empty buffer");
         DEBUG_ASSERT_EQ(buf.size() % word_size_bytes(), 0, "compact bitset buffer size must be multiple of word size");
         nbits_ = buf.size() * 8;
@@ -63,7 +64,7 @@ public:
     }
 
     ~CompactBitSet() {
-        if (allocated_) { delete[] uintptr_cast(s_); }
+        if (allocated_) { delete[] reinterpret_cast< uint8_t* >(s_); }
     }
 
     bit_count_t size() const { return nbits_; }

--- a/include/sisl/fds/stream_tracker.hpp
+++ b/include/sisl/fds/stream_tracker.hpp
@@ -95,7 +95,7 @@ public:
             return;
         }
         if ((new_end_idx < m_slot_ref_idx) ||
-            (new_end_idx >= (m_slot_ref_idx + int64_cast(m_active_slot_bits.size())))) {
+            (new_end_idx >= (m_slot_ref_idx + static_cast< int64_t >(m_active_slot_bits.size())))) {
             throw std::out_of_range("Slot idx is not in range");
         }
 

--- a/include/sisl/fds/utils.hpp
+++ b/include/sisl/fds/utils.hpp
@@ -219,41 +219,4 @@ static int spaceship_oper(const T& left, const T& right) {
 #define bind_this(method, nparams)                                                                                     \
     std::bind(&method, this BOOST_PP_REPEAT_FROM_TO(1, BOOST_PP_INC(nparams), _PLACEHOLDER_PARAM, std::placeholders::_))
 
-#define r_cast reinterpret_cast
-#define s_cast static_cast
-#define d_cast dynamic_cast
-#define dp_cast std::dynamic_pointer_cast
-#define sp_cast std::static_pointer_cast
-
-#define uintptr_cast reinterpret_cast< uint8_t* >
-#define voidptr_cast reinterpret_cast< void* >
-#define c_voidptr_cast reinterpret_cast< const void* >
-#define charptr_cast reinterpret_cast< char* >
-#define c_charptr_cast reinterpret_cast< const char* >
-#define int_cast static_cast< int >
-#define uint32_cast static_cast< uint32_t >
-#define int64_cast static_cast< int64_t >
-#define uint64_cast static_cast< uint64_t >
-#define size_cast static_cast< size_t >
-
 } // namespace sisl
-
-#if 0
-template < typename T >
-using d_cast = dynamic_cast< T >;
-
-template < typename T >
-using s_cast = static_cast< T >;
-
-template < typename T >
-using r_cast = reinterpret_cast< T >;
-
-using void_cast = reinterpret_cast< void* >;
-using uint8p_cast = reinterpret_cast< uint8_t* >;
-
-template < typename T >
-using dp_cast = std::dynamic_pointer_cast< T >;
-
-template < typename T >
-using sp_cast = std::static_pointer_cast< T >;
-#endif

--- a/include/sisl/flip/flip.hpp
+++ b/include/sisl/flip/flip.hpp
@@ -199,15 +199,6 @@ struct val_converter< int > {
     int operator()(const ParamValue& val) { return (val.kind_case() == ParamValue::kIntValue) ? val.int_value() : 0; }
 };
 
-#if 0
-template <>
-struct val_converter<const int> {
-    const int operator()(const ParamValue &val) {
-        return (val.kind_case() == ParamValue::kIntValue) ? val.int_value() : 0;
-    }
-};
-#endif
-
 template <>
 struct val_converter< long > {
     long operator()(const ParamValue& val) {

--- a/include/sisl/http/http_server.hpp
+++ b/include/sisl/http/http_server.hpp
@@ -57,14 +57,16 @@ public:
     void setup_route(http_method method, std::string resource, http_handler handler,
                      url_type const& type = url_type::regular);
     void setup_routes(std::span< const http_route > routes);
-    void setup_routes(std::initializer_list< http_route > routes) { setup_routes(std::span< const http_route >{routes}); }
+    void setup_routes(std::initializer_list< http_route > routes) {
+        setup_routes(std::span< const http_route >{routes});
+    }
 
     void start();
     void stop();
     void restart(std::string const& ssl_cert, std::string const& ssl_key);
 
 #ifdef PROMETHEUS_METRICS_REPORTER
-    // Registers GET /metrics → MetricsFarm::report(kTextFormat). Call before start().
+    // Registers GET /metrics → MetricsFarm::report(TEXT_FORMAT). Call before start().
     void register_metrics_endpoint();
 #endif
 

--- a/include/sisl/logging/logging.h
+++ b/include/sisl/logging/logging.h
@@ -252,9 +252,9 @@ const T& unmove(T&& x) {
     }
 
 #define _ABORT_OR_DUMP(is_log_assert)                                                                                  \
-    assert(0);                                                                                                         \
     if (is_log_assert) {                                                                                               \
-        if (sisl::logging::is_crash_handler_installed()) { raise(SIGUSR3); }                                           \
+        sisl::logging::log_stack_trace(false);                                                                         \
+        assert(0);                                                                                                     \
     } else {                                                                                                           \
         abort();                                                                                                       \
     }

--- a/include/sisl/metrics/reporter.hpp
+++ b/include/sisl/metrics/reporter.hpp
@@ -24,7 +24,7 @@
 namespace sisl {
 using metric_label = std::pair< std::string, std::string >;
 
-enum ReportFormat { kUnknownFormat, kTextFormat, kJsonFormat, kProtoBufferFormat };
+enum ReportFormat { UNKNOWN_FORMAT, TEXT_FORMAT, JSON_FORMAT, PROTO_BUFFER_FORMAT };
 
 class ReportCounter {
 public:

--- a/src/cache/lru_evictor.cpp
+++ b/src/cache/lru_evictor.cpp
@@ -22,7 +22,7 @@ namespace sisl {
 LRUEvictor::LRUEvictor(const int64_t max_size, const uint32_t num_partitions) : Evictor(max_size, num_partitions) {
     m_partitions = std::make_unique< LRUPartition[] >(num_partitions);
     for (uint32_t i{0}; i < num_partitions; ++i) {
-        m_partitions[i].init(this, i, uint64_cast(max_size / num_partitions));
+        m_partitions[i].init(this, i, static_cast< uint64_t >(max_size / num_partitions));
     }
 }
 

--- a/src/cache/tests/test_range_cache.cpp
+++ b/src/cache/tests/test_range_cache.cpp
@@ -126,9 +126,9 @@ private:
             static constexpr uint32_t max_blk_size = (1 * 1024 * 1024);
             LOGINFO("File {} being filled with random bytes for size={}", fname, chunk_size);
             while (filled_size < chunk_size) {
-                uint32_t this_size = std::min(uint32_cast(chunk_size - filled_size), max_blk_size);
+                uint32_t this_size = std::min(static_cast< uint32_t >(chunk_size - filled_size), max_blk_size);
                 auto data = generate_data(this_size);
-                auto size = ::write(fd, voidptr_cast(data.bytes()), this_size);
+                auto size = ::write(fd, reinterpret_cast< void* >(data.bytes()), this_size);
                 data.buf_free();
                 ASSERT_EQ(size, this_size);
                 filled_size += this_size;
@@ -140,7 +140,7 @@ private:
     sisl::io_blob generate_data(const uint32_t buf_size) {
         sisl::io_blob blob{buf_size, 0};
         random_bytes_engine rbe;
-        auto* buf = r_cast< uint64_t* >(blob.bytes());
+        auto* buf = reinterpret_cast< uint64_t* >(blob.bytes());
         for (uint32_t s{0}; s < buf_size / 8; ++s) {
             buf[s] = rbe();
         }
@@ -160,14 +160,16 @@ private:
     }
 
     void file_write(const uint32_t chunk_num, const uint32_t start_blk, sisl::io_blob& b) {
-        const auto written = ::pwrite(m_fds[chunk_num], voidptr_cast(b.bytes()), b.size(), (start_blk * g_blk_size));
+        const auto written =
+            ::pwrite(m_fds[chunk_num], reinterpret_cast< void* >(b.bytes()), b.size(), (start_blk * g_blk_size));
         RELEASE_ASSERT_EQ(written, b.size(), "Not entire data is written to file");
     }
 
     sisl::io_blob file_read(const uint32_t chunk_num, const uint32_t blk, const uint32_t nblks) {
         sisl::io_blob b{nblks * g_blk_size, 0};
-        const auto read_size = ::pread(m_fds[chunk_num], voidptr_cast(b.bytes()), b.size(), (blk * g_blk_size));
-        RELEASE_ASSERT_EQ(uint32_cast(read_size), b.size(), "Not entire data is read from file");
+        const auto read_size =
+            ::pread(m_fds[chunk_num], reinterpret_cast< void* >(b.bytes()), b.size(), (blk * g_blk_size));
+        RELEASE_ASSERT_EQ(static_cast< uint32_t >(read_size), b.size(), "Not entire data is read from file");
         return b;
     }
 
@@ -211,7 +213,7 @@ TEST_F(RangeCacheTest, RandomData) {
     auto num_iters = SISL_OPTIONS["num_iters"].as< uint32_t >();
     LOGINFO("INFO: Do random read/write operations on all chunks for {} iters", num_iters);
     for (uint32_t i{0}; i < num_iters; ++i) {
-        const op_t op = s_cast< op_t >(op_generator(g_re));
+        const op_t op = static_cast< op_t >(op_generator(g_re));
         const auto chunk_num = chunk_generator(g_re);
         const uint32_t start_blk = blk_generator(g_re);
         uint32_t nblks = nblks_generator(g_re);

--- a/src/cache/tests/test_range_hashmap.cpp
+++ b/src/cache/tests/test_range_hashmap.cpp
@@ -173,7 +173,7 @@ TEST_F(RangeHashMapTest, RandomEverythingTest) {
     LOGINFO("INFO: Do completely random read/insert/erase operations for {} entries for {} iters", g_max_offset,
             num_iters);
     for (uint32_t i{0}; i < num_iters; ++i) {
-        const op_t op = s_cast< op_t >(g_op_generator(g_re));
+        const op_t op = static_cast< op_t >(g_op_generator(g_re));
         const big_offset_t offset = offset_generator(g_re);
         big_count_t size = g_size_generator(g_re);
         if (size + offset >= g_max_offset) { size = g_max_offset - offset - 1; }

--- a/src/cache/tests/test_simple_cache.cpp
+++ b/src/cache/tests/test_simple_cache.cpp
@@ -154,7 +154,7 @@ TEST_F(SimpleCacheTest, RandomData) {
     auto num_iters = SISL_OPTIONS["num_iters"].as< uint32_t >();
     LOGINFO("INFO: Do random read/write operations on all chunks for {} iters", num_iters);
     for (uint32_t i{0}; i < num_iters; ++i) {
-        const op_t op = s_cast< op_t >(op_generator(g_re));
+        const op_t op = static_cast< op_t >(op_generator(g_re));
         const uint32_t id = key_generator(g_re);
 
         LOGDEBUG("INFO: Doing op={} for key=({})", enum_name(op), id);
@@ -187,7 +187,7 @@ TEST_F(SimpleCacheTest, MultiThreaded) {
         threads.emplace_back([this]() {
             for (uint32_t j{0}; j < 20000; ++j) {
                 const uint32_t id = g_re() % m_total_keys;
-                const op_t op = s_cast< op_t >(g_re() % 3);
+                const op_t op = static_cast< op_t >(g_re() % 3);
                 std::shared_ptr< Entry > e = std::make_shared< Entry >(0);
                 switch (op) {
                 case op_t::READ:

--- a/src/fds/tests/test_compact_bitset.cpp
+++ b/src/fds/tests/test_compact_bitset.cpp
@@ -38,7 +38,7 @@ protected:
 public:
     CompactBitsetTest() :
             testing::Test(),
-            m_buf{uint32_cast(
+            m_buf{static_cast< uint32_t >(
                 sisl::round_up(SISL_OPTIONS["buf_size"].as< uint32_t >(), CompactBitSet::size_multiples()))} {}
     CompactBitsetTest(const CompactBitsetTest&) = delete;
     CompactBitsetTest(CompactBitsetTest&&) noexcept = delete;
@@ -104,7 +104,7 @@ TEST_F(CompactBitsetTest, RandomBitsWithReload) {
     for (uint64_t i{0}; i < num_bits / 2; ++i) {
         auto bit = bit_gen(re);
         shadow_bset.set(bit);
-        m_bset->set_bit(s_cast< CompactBitSet::bit_count_t >(bit));
+        m_bset->set_bit(static_cast< CompactBitSet::bit_count_t >(bit));
     }
 
     auto validate = [this, &shadow_bset]() {

--- a/src/fds/tests/test_sg_list.cpp
+++ b/src/fds/tests/test_sg_list.cpp
@@ -112,7 +112,7 @@ public:
 
     void TearDown() override {
         for (auto& iov : sgl.iovs) {
-            auto data_ptr = r_cast< uint32_t* >(iov.iov_base);
+            auto data_ptr = reinterpret_cast< uint32_t* >(iov.iov_base);
             delete data_ptr;
         }
     }
@@ -137,10 +137,10 @@ TEST_F(SgListTestOffset, TestMoveOffsetAligned) {
     for (uint16_t i = 0; i < data_vec.size(); ++i) {
         auto const iovs = sgitr.next_iovs(SZ);
         ASSERT_EQ(iovs.size(), 1);
-        auto rand_num = r_cast< uint32_t* >(iovs[0].iov_base);
+        auto rand_num = reinterpret_cast< uint32_t* >(iovs[0].iov_base);
         EXPECT_EQ(*rand_num, data_vec[i]);
 
-        rand_num = r_cast< uint32_t* >(ioblob_list[i].bytes());
+        rand_num = reinterpret_cast< uint32_t* >(ioblob_list[i].bytes());
         EXPECT_EQ(*rand_num, data_vec[i]);
         EXPECT_EQ(ioblob_list[i].size(), SZ);
     }
@@ -154,7 +154,7 @@ TEST_F(SgListTestOffset, TestMoveOffsetAligned) {
         }
         auto const iovs = sgitr1.next_iovs(SZ);
         ASSERT_EQ(iovs.size(), 1);
-        auto rand_num = r_cast< uint32_t* >(iovs[0].iov_base);
+        auto rand_num = reinterpret_cast< uint32_t* >(iovs[0].iov_base);
         EXPECT_EQ(*rand_num, data_vec[i]);
     }
 }

--- a/src/grpc/rpc_client.cpp
+++ b/src/grpc/rpc_client.cpp
@@ -227,7 +227,7 @@ io_blob GenericClientResponse::response_blob() {
         m_response_buf.Clear(); // Since we dumped everything to a single slice, we don't need bytebyffer anymore
     }
 
-    auto const size = uint32_cast(m_single_slice.size());
+    auto const size = static_cast< uint32_t >(m_single_slice.size());
     return size ? io_blob{m_single_slice.begin(), size, false /* is_aligned */} : io_blob{};
 }
 

--- a/src/grpc/tests/function/echo_async_client.cpp
+++ b/src/grpc/tests/function/echo_async_client.cpp
@@ -113,7 +113,8 @@ static void SerializeToBlob(sisl::io_blob_list_t& buffer, const DataMessage& msg
     std::string str_msg;
     msg.SerializeToString(str_msg);
     auto buf = sisl::io_blob(str_msg.size());
-    std::memcpy(voidptr_cast(buf.bytes()), c_voidptr_cast(str_msg.data()), str_msg.size());
+    std::memcpy(reinterpret_cast< void* >(buf.bytes()), reinterpret_cast< const void* >(str_msg.data()),
+                str_msg.size());
     buffer.emplace_back(buf);
 }
 

--- a/src/grpc/tests/unit/client_test.cpp
+++ b/src/grpc/tests/unit/client_test.cpp
@@ -62,7 +62,9 @@ static std::pair< std::string, grpc::ByteBuffer > create_test_byte_buffer(uint32
     return std::pair{concat_str, grpc::ByteBuffer{slices.data(), slices.size()}};
 }
 
-static std::string blob_to_string(io_blob const& b) { return std::string(c_charptr_cast(b.cbytes()), b.size()); }
+static std::string blob_to_string(io_blob const& b) {
+    return std::string(reinterpret_cast< const char* >(b.cbytes()), b.size());
+}
 
 static void do_test(std::string const& msg, grpc::ByteBuffer& bbuf) {
     GenericClientResponse resp1(bbuf);

--- a/src/grpc/utils.hpp
+++ b/src/grpc/utils.hpp
@@ -65,7 +65,8 @@ namespace sisl {
     auto status = cli_byte_buf.DumpToSingleSlice(&slice);
     if (status.ok()) {
         cli_buf.buf_alloc(slice.size());
-        std::memcpy(voidptr_cast(cli_buf.bytes()), c_voidptr_cast(slice.begin()), slice.size());
+        std::memcpy(reinterpret_cast< void* >(cli_buf.bytes()), reinterpret_cast< const void* >(slice.begin()),
+                    slice.size());
     }
     return status;
 }

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -220,7 +220,7 @@ void HttpServer::register_metrics_endpoint() {
     setup_route(
         http_method::Get, "/metrics",
         [](httplib::Request const&, httplib::Response& res) {
-            res.set_content(sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::kTextFormat), "text/plain");
+            res.set_content(sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::TEXT_FORMAT), "text/plain");
         },
         url_type::safe);
 }

--- a/src/logging/stacktrace.cpp
+++ b/src/logging/stacktrace.cpp
@@ -42,6 +42,11 @@
 namespace sisl {
 namespace logging {
 
+// Public one-arg wrapper declared in logging.h. The internal two-arg overloads are static
+// (internal linkage) inside stacktrace_debug.h / stacktrace_release.h; they cannot be
+// referenced from other TUs. This wrapper closes the ABI hole.
+void log_stack_trace(const bool all_threads) { log_stack_trace(all_threads, 0); }
+
 typedef struct SignalHandlerData {
     SignalHandlerData(std::string name, const sig_handler_t handler) : name{std::move(name)}, handler{handler} {}
     std::string name;
@@ -83,11 +88,10 @@ static void exit_with_default_sighandler(const SignalType fatal_signal_id) {
     }
 
     // If core dump file generation is enabled and the signal is one that generates a core dump, re-raise the signal
-    const std::unordered_set<SignalType> core_dump_signals = {SIGABRT, SIGFPE, SIGSEGV, SIGILL};
+    const std::unordered_set< SignalType > core_dump_signals = {SIGABRT, SIGFPE, SIGSEGV, SIGILL};
     if (SISL_OPTIONS["enable_core_dump"].count() && core_dump_signals.count(fatal_signal_id) > 0) {
         std::cerr << "\n"
-                  << __FUNCTION__ << ":" << __LINE__ << ". Raising signal "
-                  << fatal_signal_id << "   \n\n"
+                  << __FUNCTION__ << ":" << __LINE__ << ". Raising signal " << fatal_signal_id << "   \n\n"
                   << std::flush;
         std::raise(fatal_signal_id);
         return;

--- a/src/metrics/prometheus_reporter.cpp
+++ b/src/metrics/prometheus_reporter.cpp
@@ -72,7 +72,7 @@ void PrometheusReportSumCount::set_value(int64_t count, double sum) {
 PrometheusReporter::PrometheusReporter() {
     m_registry = std::make_shared< prometheus::Registry >();
     m_serializer = std::make_unique< prometheus::TextSerializer >();
-    m_cur_serializer_format = kTextFormat;
+    m_cur_serializer_format = TEXT_FORMAT;
 }
 
 std::shared_ptr< ReportCounter > PrometheusReporter::add_counter(const std::string& name, const std::string& desc,
@@ -234,12 +234,12 @@ void PrometheusReporter::remove_sum_count(const std::string& name, const std::sh
 std::string PrometheusReporter::serialize(ReportFormat format) {
     if (format != m_cur_serializer_format) {
         switch (format) {
-        case ReportFormat::kTextFormat:
+        case ReportFormat::TEXT_FORMAT:
             m_serializer = std::make_unique< prometheus::TextSerializer >();
             break;
         default:
             assert(0);
-            format = ReportFormat::kTextFormat;
+            format = ReportFormat::TEXT_FORMAT;
             m_serializer = std::make_unique< prometheus::TextSerializer >();
         }
         m_cur_serializer_format = format;

--- a/src/metrics/tests/farm_test.cpp
+++ b/src/metrics/tests/farm_test.cpp
@@ -37,8 +37,8 @@ using namespace sisl;
 
 class Group1Metrics : public MetricsGroup {
 public:
-    explicit Group1Metrics(const char* inst_name)
-        : MetricsGroup("Group1", inst_name, group_impl_type_t::thread_buf_signal) {
+    explicit Group1Metrics(const char* inst_name) :
+            MetricsGroup("Group1", inst_name, group_impl_type_t::thread_buf_signal) {
         REGISTER_COUNTER(counter1, "Counter1");
         REGISTER_COUNTER(counter2, "Counter2");
         REGISTER_COUNTER(counter3, "Counter3");
@@ -49,8 +49,8 @@ public:
 
 class Group2Metrics : public MetricsGroup {
 public:
-    explicit Group2Metrics(const char* inst_name)
-        : MetricsGroup("Group2", inst_name, group_impl_type_t::thread_buf_signal) {
+    explicit Group2Metrics(const char* inst_name) :
+            MetricsGroup("Group2", inst_name, group_impl_type_t::thread_buf_signal) {
         REGISTER_GAUGE(gauge1, "Gauge1");
         REGISTER_GAUGE(gauge2, "Gauge2");
         register_me_to_farm();
@@ -162,8 +162,8 @@ TEST(FarmTest, gather) {
 // Helper class for DirectAccess tests
 class TestMetrics : public MetricsGroup {
 public:
-    explicit TestMetrics(const char* inst_name, group_impl_type_t type = group_impl_type_t::rcu)
-        : MetricsGroup("TestGroup", inst_name, type) {
+    explicit TestMetrics(const char* inst_name, group_impl_type_t type = group_impl_type_t::rcu) :
+            MetricsGroup("TestGroup", inst_name, type) {
         REGISTER_COUNTER(test_counter, "Test counter");
         REGISTER_GAUGE(test_gauge, "Test gauge");
         REGISTER_HISTOGRAM(test_histogram, "Test histogram");
@@ -213,10 +213,14 @@ INSTANTIATE_TEST_SUITE_P(AllImplementations, DirectAccessTest,
                                            group_impl_type_t::thread_buf_signal),
                          [](const ::testing::TestParamInfo< group_impl_type_t >& info) {
                              switch (info.param) {
-                             case group_impl_type_t::rcu: return "RCU";
-                             case group_impl_type_t::atomic: return "Atomic";
-                             case group_impl_type_t::thread_buf_signal: return "ThreadLocal";
-                             default: return "Unknown";
+                             case group_impl_type_t::rcu:
+                                 return "RCU";
+                             case group_impl_type_t::atomic:
+                                 return "Atomic";
+                             case group_impl_type_t::thread_buf_signal:
+                                 return "ThreadLocal";
+                             default:
+                                 return "Unknown";
                              }
                          });
 
@@ -240,7 +244,7 @@ TEST(FarmTest, TestHistogramSumCount) {
     HISTOGRAM_OBSERVE(*mg, test_latency, 30);
 
     // Get Prometheus output
-    auto output = sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::kTextFormat);
+    auto output = sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::TEXT_FORMAT);
 
     // Should contain sum and count, not buckets
     EXPECT_TRUE(output.find("test_latency_sum") != std::string::npos);

--- a/src/metrics/tests/wrapper_test.cpp
+++ b/src/metrics/tests/wrapper_test.cpp
@@ -246,7 +246,7 @@ TEST(counterTest, wrapperTest) {
         std::cerr << "Diff patch " << std::setw(4) << patch << "\n";
     }
 
-    auto prometheus_bytes = MetricsFarm::getInstance().report(ReportFormat::kTextFormat);
+    auto prometheus_bytes = MetricsFarm::getInstance().report(ReportFormat::TEXT_FORMAT);
     // std::cout << "Prometheus serialized format: " << prometheus_bytes << "\n";
 }
 

--- a/src/settings/tests/test_app_schema.fbs
+++ b/src/settings/tests/test_app_schema.fbs
@@ -6,28 +6,28 @@ attribute "hotswap";
 attribute "deprecated";
 
 table DatabaseSettings {
-    databaseHost: string;                          
-    databasePort: uint32 = 27017;                   
-    numThreads: uint32 = 8;
+    database_host: string;
+    database_port: uint32 = 27017;
+    num_threads: uint32 = 8;
 }
 
 table DBConnection {
-    minDBConnections: uint32 = 2;
-    maxDBConnections: uint32 = 10;
-    dbConnectionOptimalLoad: uint64 = 100 (hotswap);
-    dbConnectionMaxLoad: uint64 (deprecated);
+    min_db_connections: uint32 = 2;
+    max_db_connections: uint32 = 10;
+    db_connection_optimal_load: uint64 = 100 (hotswap);
+    db_connection_max_load: uint64 (deprecated);
 }
 
 table Glog {
-    FLAGS_v: uint32 = 1;
-    FLAGS_max_log_size: uint32 = 50;
-    FLAGS_logtostderr: uint32 = 0;
+    flags_v: uint32 = 1;
+    flags_max_log_size: uint32 = 50;
+    flags_logtostderr: uint32 = 0;
     //Buffer log messages logged at this level or lower";0-INFO, 1-WARNING, 2-ERROR, 3-FATAL
-    FLAGS_logbuflevel: int32 = 0;
+    flags_logbuflevel: int32 = 0;
     //copy GLOG levels at above this level to stderr;
-    FLAGS_stderrthreshold: int32 = 3;
-    FLAGS_alsologtostderr: uint32 = 0;
-    FLAGS_vmodule: string (hotswap);
+    flags_stderrthreshold: int32 = 3;
+    flags_alsologtostderr: uint32 = 0;
+    flags_vmodule: string (hotswap);
 }
 
 table Config {
@@ -42,4 +42,3 @@ table TestAppSettings {
 }
 
 root_type TestAppSettings;
-

--- a/src/settings/tests/test_settings.cpp
+++ b/src/settings/tests/test_settings.cpp
@@ -59,12 +59,12 @@ TEST_F(SettingsTest, LoadReload) {
     init();
 
     LOGINFO("Step 1: Validating default load");
-    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->dbconnection->dbConnectionOptimalLoad), 100UL)
-        << "Incorrect load of dbConnectionOptimalLoad - default load";
+    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->dbconnection->db_connection_optimal_load), 100UL)
+        << "Incorrect load of db_connection_optimal_load - default load";
     SETTINGS(test_app_schema, s, {
-        ASSERT_EQ(s.config.database.databaseHost, "") << "Incorrect load of databaseHost - default load";
-        ASSERT_EQ(s.config.database.databasePort, 27017u) << "Incorrect load of databasePort - default load";
-        ASSERT_EQ(s.config.database.numThreads, 8u) << "Incorrect load of numThreads - default load";
+        ASSERT_EQ(s.config.database.database_host, "") << "Incorrect load of database_host - default load";
+        ASSERT_EQ(s.config.database.database_port, 27017u) << "Incorrect load of database_port - default load";
+        ASSERT_EQ(s.config.database.num_threads, 8u) << "Incorrect load of num_threads - default load";
     });
     sisl::SettingsFactoryRegistry::instance().save_all();
     ASSERT_EQ(std::filesystem::exists("/tmp/test_app_schema.json"), true) << "Expect settings save to create the file";
@@ -73,21 +73,21 @@ TEST_F(SettingsTest, LoadReload) {
 
     LOGINFO("Step 2: Reload by dumping the settings to json, edit hotswap variable and reload it");
     nlohmann::json j = nlohmann::json::parse(SETTINGS_FACTORY(test_app_schema).get_json());
-    j["config"]["dbconnection"]["dbConnectionOptimalLoad"] = 800;
+    j["config"]["dbconnection"]["db_connection_optimal_load"] = 800;
     ASSERT_EQ(SETTINGS_FACTORY(test_app_schema).reload_json(j.dump()), false)
         << "Incorrectly asking restart when hotswap variable is changed and reloaded";
-    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->dbconnection->dbConnectionOptimalLoad), 800UL)
-        << "Incorrect load of dbConnectionOptimalLoad - after reload json";
+    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->dbconnection->db_connection_optimal_load), 800UL)
+        << "Incorrect load of db_connection_optimal_load - after reload json";
     SETTINGS(test_app_schema, s, {
-        ASSERT_EQ(s.config.database.databaseHost, "") << "Incorrect load of databaseHost - after reload json";
-        ASSERT_EQ(s.config.database.databasePort, 27017u) << "Incorrect load of databasePort - after reload json";
-        ASSERT_EQ(s.config.database.numThreads, 8u) << "Incorrect load of numThreads - after reload json";
+        ASSERT_EQ(s.config.database.database_host, "") << "Incorrect load of database_host - after reload json";
+        ASSERT_EQ(s.config.database.database_port, 27017u) << "Incorrect load of database_port - after reload json";
+        ASSERT_EQ(s.config.database.num_threads, 8u) << "Incorrect load of num_threads - after reload json";
     });
 
     LOGINFO("Step 3: Reload by dumping the settings to json, edit non-hotswap variable and dump to file and reload "
             "settings");
     j = nlohmann::json::parse(SETTINGS_FACTORY(test_app_schema).get_json());
-    j["config"]["database"]["databasePort"] = 25000u;
+    j["config"]["database"]["database_port"] = 25000u;
     {
         std::ofstream file(g_schema_file);
         file << j;
@@ -97,39 +97,39 @@ TEST_F(SettingsTest, LoadReload) {
 
     LOGINFO("Step 4: Simulate the app restart and validate new values");
     init();
-    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->dbconnection->dbConnectionOptimalLoad), 800UL)
-        << "Incorrect load of dbConnectionOptimalLoad - after restart";
+    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->dbconnection->db_connection_optimal_load), 800UL)
+        << "Incorrect load of db_connection_optimal_load - after restart";
     SETTINGS(test_app_schema, s, {
-        ASSERT_EQ(s.config.database.databaseHost, "") << "Incorrect load of databaseHost - after reload json";
-        ASSERT_EQ(s.config.database.databasePort, 25000u) << "Incorrect load of databasePort - after reload json";
-        ASSERT_EQ(s.config.database.numThreads, 8u) << "Incorrect load of numThreads - after reload json";
+        ASSERT_EQ(s.config.database.database_host, "") << "Incorrect load of database_host - after reload json";
+        ASSERT_EQ(s.config.database.database_port, 25000u) << "Incorrect load of database_port - after reload json";
+        ASSERT_EQ(s.config.database.num_threads, 8u) << "Incorrect load of num_threads - after reload json";
     });
     sisl::SettingsFactoryRegistry::instance().save_all();
 }
 
 TEST_F(SettingsTest, OverrideConfig) {
     LOGINFO("Step 1: Validating overridden config load");
-    init({"test_app_schema.config.database.databaseHost:myhost.com",
-          "test_app_schema.config.glog.FLAGS_logbuflevel:100"});
-    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->database->databaseHost), "myhost.com")
-        << "Incorrect load of databaseHost with override config";
-    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->glog->FLAGS_logbuflevel), 100)
-        << "Incorrect load of FLAGS_logbuflevel with override config";
+    init({"test_app_schema.config.database.database_host:myhost.com",
+          "test_app_schema.config.glog.flags_logbuflevel:100"});
+    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->database->database_host), "myhost.com")
+        << "Incorrect load of database_host with override config";
+    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->glog->flags_logbuflevel), 100)
+        << "Incorrect load of flags_logbuflevel with override config";
     SETTINGS(test_app_schema, s, {
-        ASSERT_EQ(s.config.database.databasePort, 27017u) << "Incorrect load of databasePort - default load";
-        ASSERT_EQ(s.config.database.numThreads, 8u) << "Incorrect load of numThreads - default load";
+        ASSERT_EQ(s.config.database.database_port, 27017u) << "Incorrect load of database_port - default load";
+        ASSERT_EQ(s.config.database.num_threads, 8u) << "Incorrect load of num_threads - default load";
     });
     sisl::SettingsFactoryRegistry::instance().save_all();
 
     LOGINFO("Step 2: Simulate restart and default load saved the previously overridden config");
     init();
-    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->database->databaseHost), "myhost.com")
-        << "Incorrect load of databaseHost with override config";
-    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->glog->FLAGS_logbuflevel), 100)
-        << "Incorrect load of FLAGS_logbuflevel with override config";
+    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->database->database_host), "myhost.com")
+        << "Incorrect load of database_host with override config";
+    ASSERT_EQ(SETTINGS_VALUE(test_app_schema, config->glog->flags_logbuflevel), 100)
+        << "Incorrect load of flags_logbuflevel with override config";
     SETTINGS(test_app_schema, s, {
-        ASSERT_EQ(s.config.database.databasePort, 27017u) << "Incorrect load of databasePort - default load";
-        ASSERT_EQ(s.config.database.numThreads, 8u) << "Incorrect load of numThreads - default load";
+        ASSERT_EQ(s.config.database.database_port, 27017u) << "Incorrect load of database_port - default load";
+        ASSERT_EQ(s.config.database.num_threads, 8u) << "Incorrect load of num_threads - default load";
     });
 }
 
@@ -142,38 +142,38 @@ int main(int argc, char* argv[]) {
     // MY_SETTINGS_FACTORY.load_file("/tmp/settings_in.json");
 
     LOGINFO("After Initial load values are:");
-    LOGINFO("dbConnectionOptimalLoad = {} ",
-            SETTINGS_VALUE(test_app_schema, config->dbconnection->dbConnectionOptimalLoad));
+    LOGINFO("db_connection_optimal_load = {} ",
+            SETTINGS_VALUE(test_app_schema, config->dbconnection->db_connection_optimal_load));
     MY_SETTINGS_FACTORY.save("/tmp/settings_out");
     SETTINGS(test_app_schema, s, {
-        LOGINFO("databaseHost = {}", s.config.database.databaseHost);
-        LOGINFO("databasePort = {}", s.config.database.databasePort);
-        LOGINFO("numThreads = {}", s.config.database.numThreads);
+        LOGINFO("database_host = {}", s.config.database.database_host);
+        LOGINFO("database_port = {}", s.config.database.database_port);
+        LOGINFO("num_threads = {}", s.config.database.num_threads);
     });
 
     LOGINFO("Reload - 1 file: restart needed {}", MY_SETTINGS_FACTORY.reload_file("/tmp/settings_out.json"));
 
     nlohmann::json j;
     j = nlohmann::json::parse(MY_SETTINGS_FACTORY.get_json());
-    j["config"]["dbconnection"]["dbConnectionOptimalLoad"] = 800;
+    j["config"]["dbconnection"]["db_connection_optimal_load"] = 800;
     LOGINFO("Reload - 2 json after changes, restart needed {} ", MY_SETTINGS_FACTORY.reload_json(j.dump()));
     LOGINFO("After reload - 2: values are:");
-    LOGINFO("dbConnectionOptimalLoad = {} ",
-            SETTINGS_VALUE(test_app_schema, config->dbconnection->dbConnectionOptimalLoad));
+    LOGINFO("db_connection_optimal_load = {} ",
+            SETTINGS_VALUE(test_app_schema, config->dbconnection->db_connection_optimal_load));
     SETTINGS(test_app_schema, s, {
-        LOGINFO("databasePort = {}", s.config.database.databasePort);
-        LOGINFO("numThreads = {}", s.config.database.numThreads);
+        LOGINFO("database_port = {}", s.config.database.database_port);
+        LOGINFO("num_threads = {}", s.config.database.num_threads);
     });
 
     j = nlohmann::json::parse(MY_SETTINGS_FACTORY.get_json());
-    j["config"]["database"]["databasePort"] = 25000;
+    j["config"]["database"]["database_port"] = 25000;
     LOGINFO("Reload - 3 json after changes, restart needed {} ", MY_SETTINGS_FACTORY.reload_json(j.dump()));
     LOGINFO("After reload - 3: values are:");
-    LOGINFO("dbConnectionOptimalLoad = {} ",
-            SETTINGS_VALUE(test_app_schema, config->dbconnection->dbConnectionOptimalLoad));
+    LOGINFO("db_connection_optimal_load = {} ",
+            SETTINGS_VALUE(test_app_schema, config->dbconnection->db_connection_optimal_load));
     SETTINGS(test_app_schema, s, {
-        LOGINFO("databasePort = {}", s.config.database.databasePort);
-        LOGINFO("numThreads = {}", s.config.database.numThreads);
+        LOGINFO("database_port = {}", s.config.database.database_port);
+        LOGINFO("num_threads = {}", s.config.database.num_threads);
     });
 
     MY_SETTINGS_FACTORY.save("/tmp/settings_out");

--- a/src/utility/tests/test_objlife_counter.cpp
+++ b/src/utility/tests/test_objlife_counter.cpp
@@ -68,7 +68,7 @@ TEST_F(ObjLifeTest, BasicCount) {
     const nlohmann::json j{sisl::MetricsFarm::getInstance().get_result_in_json()};
     std::cout << "Json output = " << j.dump(2);
 
-    const auto prom_format{sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::kTextFormat)};
+    const auto prom_format{sisl::MetricsFarm::getInstance().report(sisl::ReportFormat::TEXT_FORMAT)};
     std::cout << "Prometheus Output = " << prom_format;
     EXPECT_TRUE(prom_format.find(R"(TestClass_double__sisl::blob_{entity="Singleton",type="alive"} 1)") !=
                 std::string::npos);


### PR DESCRIPTION
…warning

- Remove all 15 cast shorthand macros (r_cast, s_cast, d_cast, dp_cast, sp_cast, uintptr_cast, voidptr_cast, c_voidptr_cast, charptr_cast, c_charptr_cast, int_cast, uint32_cast, int64_cast, uint64_cast, size_cast) from fds/utils.hpp; expand all 48 call sites to the real C++ cast keyword so IDEs highlight them correctly
- Rename ReportFormat enumerators from Google-style kCamelCase to SCREAMING_SNAKE_CASE (kTextFormat → TEXT_FORMAT, etc.) across reporter.hpp, prometheus_reporter.cpp, http_server.cpp, and tests
- Rename FlatBuffers test schema fields to snake_case to silence flatc warnings; update all field references in test_settings.cpp
- Suppress macOS duplicate-library linker warnings with -Wl,-no_warn_duplicate_libraries; Conan's CMakeDeps generator expands transitive absolute-path libs at each step so the same .a appears multiple times — ld ignores extras, but warns since Xcode 15