### PR TITLE
Fix/file watcher race

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -121,7 +121,7 @@ class SISLConan(ConanFile):
         cmake.configure()
         cmake.build()
         if not self.conf.get("tools.build:skip_test", default=False):
-            cmake.test()
+            self.run(f"ctest --test-dir '{self.build_folder}' --output-on-failure")
 
     def package(self):
         lib_dir = join(self.package_folder, "lib")

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "8.9.6"
+    version = "8.9.7"
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"
     topics = ("ebay", "components", "core", "efficiency")

--- a/include/sisl/file_watcher/file_watcher.hpp
+++ b/include/sisl/file_watcher/file_watcher.hpp
@@ -1,6 +1,7 @@
 // This implementation of file watcher only works on Linux machines.
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <sisl/logging/logging.h>
 #include <thread>
@@ -18,13 +19,15 @@ struct FileInfo {
     // closures to be called when file modification is detected, one per listener
     std::map< std::string, file_event_cb_t > m_handlers;
     int m_wd;
+    bool m_pending_modify{false};
+    std::chrono::steady_clock::time_point m_last_modify_time;
 };
 
 class FileWatcher {
 public:
     FileWatcher() = default;
 
-    bool start();
+    bool start(uint32_t debounce_ms = 200);
     bool register_listener(const std::string& file_path, const std::string& listener_id,
                            const file_event_cb_t& file_event_handler);
     bool unregister_listener(const std::string& file_path, const std::string& listener_id);
@@ -35,6 +38,8 @@ private:
     void handle_events();
     void get_fileinfo(const int wd, FileInfo& file_info) const;
     void on_modified_event(const int wd, const bool is_deleted);
+    void check_pending_modifies();
+    int next_pending_ms() const;
     bool remove_watcher(FileInfo& file_info);
     static bool get_file_contents(const std::string& file_name, std::string& contents);
     static bool check_file_size(const std::string& file_path);
@@ -46,6 +51,7 @@ private:
     std::unique_ptr< std::thread > m_fw_thread;
     // This is used to notify poll loop to exit
     int m_pipefd[2] = {-1, -1};
+    uint32_t m_debounce_ms{200};
 };
 
 } // namespace sisl

--- a/src/file_watcher/file_watcher.cpp
+++ b/src/file_watcher/file_watcher.cpp
@@ -219,6 +219,11 @@ void FileWatcher::on_modified_event(const int wd, const bool is_deleted) {
         LOGDEBUG("File contents have not changed: {}", file_info.m_filepath);
     } else {
         LOGDEBUG("File contents have changed: {}", file_info.m_filepath);
+        {
+            auto lk = std::unique_lock< std::mutex >(m_files_lock);
+            auto it = m_files.find(file_info.m_filepath);
+            if (it != m_files.end()) { it->second.m_filecontents = file_info.m_filecontents; }
+        }
         // notify file modification event
         for (const auto& [id, handler] : file_info.m_handlers) {
             handler(file_info.m_filepath, false);

--- a/src/file_watcher/file_watcher.cpp
+++ b/src/file_watcher/file_watcher.cpp
@@ -12,7 +12,8 @@
 namespace sisl {
 namespace fs = std::filesystem;
 
-bool FileWatcher::start() {
+bool FileWatcher::start(uint32_t debounce_ms) {
+    m_debounce_ms = debounce_ms;
     m_inotify_fd = inotify_init1(IN_NONBLOCK);
     // create an fd for accessing inotify
     if (m_inotify_fd == -1) {
@@ -42,7 +43,7 @@ void FileWatcher::run() {
     int poll_num;
     // start the poll loop. This will block the thread
     while (true) {
-        poll_num = poll(fds, nfds, -1);
+        poll_num = poll(fds, nfds, next_pending_ms());
         if (poll_num == -1) {
             if (errno == EINTR) { continue; }
             LOGERROR("file watcher poll command failed!, errno: {}", errno);
@@ -56,6 +57,8 @@ void FileWatcher::run() {
             }
             if (fds[1].revents & POLLIN) { handle_events(); }
         }
+
+        check_pending_modifies();
     }
 
     close(m_inotify_fd);
@@ -182,7 +185,18 @@ void FileWatcher::handle_events() {
             if ((event->mask & IN_MOVE_SELF) || (event->mask & IN_MODIFY) || (event->mask & IN_DELETE_SELF) ||
                 (event->mask & IN_UNMOUNT) || ((event->mask & IN_ATTRIB))) {
                 bool is_deleted = !(event->mask & IN_MODIFY);
-                on_modified_event(event->wd, is_deleted);
+                if (is_deleted) {
+                    on_modified_event(event->wd, true);
+                } else {
+                    auto lk = std::unique_lock< std::mutex >(m_files_lock);
+                    for (auto& [path, fi] : m_files) {
+                        if (fi.m_wd == event->wd) {
+                            fi.m_pending_modify = true;
+                            fi.m_last_modify_time = std::chrono::steady_clock::now();
+                            break;
+                        }
+                    }
+                }
             }
 
             // if the watch is removed due to file deletion or fs unmount (mask IN_IGNORED),
@@ -195,39 +209,14 @@ void FileWatcher::handle_events() {
 void FileWatcher::on_modified_event(const int wd, const bool is_deleted) {
     FileInfo file_info;
     get_fileinfo(wd, file_info);
-    if (is_deleted) {
-        // There is a corner case (very unlikely) where a new listener
-        // regestered for this filepath  after the current delete event was triggered.
-        {
-            auto lk = std::unique_lock< std::mutex >(m_files_lock);
-            remove_watcher(file_info);
-        }
-        for (const auto& [id, handler] : file_info.m_handlers) {
-            handler(file_info.m_filepath, true);
-        }
-        return;
+    // There is a corner case (very unlikely) where a new listener
+    // registered for this filepath after the current delete event was triggered.
+    {
+        auto lk = std::unique_lock< std::mutex >(m_files_lock);
+        remove_watcher(file_info);
     }
-
-    if (!check_file_size(file_info.m_filepath)) { return; }
-
-    const auto cur_buffer = file_info.m_filecontents;
-    if (!get_file_contents(file_info.m_filepath, file_info.m_filecontents)) {
-        LOGWARN("Could not read contents from the file: {}", file_info.m_filepath);
-        return;
-    }
-    if (file_info.m_filecontents == cur_buffer) {
-        LOGDEBUG("File contents have not changed: {}", file_info.m_filepath);
-    } else {
-        LOGDEBUG("File contents have changed: {}", file_info.m_filepath);
-        {
-            auto lk = std::unique_lock< std::mutex >(m_files_lock);
-            auto it = m_files.find(file_info.m_filepath);
-            if (it != m_files.end()) { it->second.m_filecontents = file_info.m_filecontents; }
-        }
-        // notify file modification event
-        for (const auto& [id, handler] : file_info.m_handlers) {
-            handler(file_info.m_filepath, false);
-        }
+    for (const auto& [id, handler] : file_info.m_handlers) {
+        handler(file_info.m_filepath, is_deleted);
     }
 }
 
@@ -266,6 +255,65 @@ void FileWatcher::get_fileinfo(const int wd, FileInfo& file_info) const {
         }
     }
     LOGWARN("wd {} not found!", wd);
+}
+
+int FileWatcher::next_pending_ms() const {
+    auto lk = std::unique_lock< std::mutex >(m_files_lock);
+    int min_remaining = -1;
+    auto now = std::chrono::steady_clock::now();
+    for (const auto& [path, fi] : m_files) {
+        if (!fi.m_pending_modify) continue;
+        auto elapsed = std::chrono::duration_cast< std::chrono::milliseconds >(now - fi.m_last_modify_time).count();
+        int remaining = std::max(1LL, static_cast< long long >(m_debounce_ms) - elapsed);
+        if (min_remaining == -1 || remaining < min_remaining) { min_remaining = remaining; }
+    }
+    return min_remaining;
+}
+
+void FileWatcher::check_pending_modifies() {
+    auto now = std::chrono::steady_clock::now();
+
+    // Collect paths whose quiet period has elapsed; clear pending flag under lock.
+    std::vector< std::string > ready_paths;
+    {
+        auto lk = std::unique_lock< std::mutex >(m_files_lock);
+        for (auto& [path, fi] : m_files) {
+            if (!fi.m_pending_modify) continue;
+            auto elapsed =
+                std::chrono::duration_cast< std::chrono::milliseconds >(now - fi.m_last_modify_time).count();
+            if (static_cast< uint32_t >(elapsed) < m_debounce_ms) continue;
+            fi.m_pending_modify = false;
+            ready_paths.push_back(path);
+        }
+    }
+
+    // Read file and fire callbacks outside the lock to avoid holding it during I/O.
+    for (const auto& path : ready_paths) {
+        if (!check_file_size(path)) continue;
+        std::string new_contents;
+        if (!get_file_contents(path, new_contents)) {
+            LOGWARN("Could not read contents from the file: {}", path);
+            continue;
+        }
+
+        std::map< std::string, file_event_cb_t > handlers;
+        {
+            auto lk = std::unique_lock< std::mutex >(m_files_lock);
+            auto it = m_files.find(path);
+            if (it == m_files.end()) continue;
+            if (new_contents == it->second.m_filecontents) {
+                LOGDEBUG("File contents have not changed after debounce: {}", path);
+                continue;
+            }
+            it->second.m_filecontents = new_contents;
+            handlers = it->second.m_handlers;
+        }
+
+        LOGDEBUG("File contents have changed: {}", path);
+        for (const auto& [id, handler] : handlers) {
+            handler(path, false);
+        }
+    }
 }
 
 } // namespace sisl

--- a/src/file_watcher/file_watcher_test.cpp
+++ b/src/file_watcher/file_watcher_test.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <fcntl.h>
+#include <unistd.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -103,6 +105,61 @@ TEST_F(FileWatcherTest, basic_watcher) {
         EXPECT_FALSE(m_file_change_params.is_deleted);
     }
     */
+}
+
+// Regression: FileWatcher used to store file contents only in a local copy and never
+// write it back to m_files, causing every subsequent IN_MODIFY to look like a content
+// change and re-fire all callbacks. Verify that an IN_MODIFY that carries the same
+// content as the last observed change does not trigger the callback again.
+//
+// Both writes use POSIX open(O_WRONLY) without O_TRUNC so that exactly one IN_MODIFY
+// fires per write with the full content already in place. std::ofstream would truncate
+// first, generating a spurious empty-content IN_MODIFY that contaminates the test.
+// "initial_content" and "updated_content" are the same length (15 bytes) so the
+// in-place write leaves no stale bytes.
+TEST_F(FileWatcherTest, no_refire_on_repeated_write) {
+    const auto file_path = fs::current_path() / "refire_test.txt";
+    fs::remove(file_path);
+    m_file_change_params.file_str = file_path.string();
+    m_file_change_params.is_deleted = false;
+    m_file_change_params.cb_call_count = 1;
+
+    // Create file with initial content BEFORE registering so the create/open
+    // does not generate an observed IN_MODIFY.
+    {
+        std::ofstream f{m_file_change_params.file_str};
+        f << "initial_content";
+        f.flush();
+    }
+
+    monitor_file_changes(m_file_change_params, "refire_listener");
+
+    // In-place write (no truncation) — exactly one IN_MODIFY with the full new content.
+    const std::string new_content{"updated_content"};
+    auto write_inplace = [&]() {
+        auto fd = open(m_file_change_params.file_str.c_str(), O_WRONLY);
+        ::write(fd, new_content.data(), new_content.size());
+        ::close(fd);
+    };
+
+    write_inplace();
+    {
+        auto lk = std::unique_lock< std::mutex >(m_file_change_params.file_change_lock);
+        EXPECT_TRUE(m_file_change_params.file_change_cv.wait_for(
+            lk, std::chrono::milliseconds(1500),
+            [this]() { return m_file_change_params.cb_call_count == 0; }));
+        EXPECT_FALSE(m_file_change_params.is_deleted);
+    }
+
+    // Write the same bytes again — callback must NOT fire.
+    m_file_change_params.cb_call_count = 1;
+    write_inplace();
+    {
+        auto lk = std::unique_lock< std::mutex >(m_file_change_params.file_change_lock);
+        EXPECT_FALSE(m_file_change_params.file_change_cv.wait_for(
+            lk, std::chrono::milliseconds(500),
+            [this]() { return m_file_change_params.cb_call_count == 0; }));
+    }
 }
 
 TEST_F(FileWatcherTest, multiple_watchers) {

--- a/src/file_watcher/file_watcher_test.cpp
+++ b/src/file_watcher/file_watcher_test.cpp
@@ -138,7 +138,8 @@ TEST_F(FileWatcherTest, no_refire_on_repeated_write) {
     const std::string new_content{"updated_content"};
     auto write_inplace = [&]() {
         auto fd = open(m_file_change_params.file_str.c_str(), O_WRONLY);
-        ::write(fd, new_content.data(), new_content.size());
+        const auto n = ::write(fd, new_content.data(), new_content.size());
+        EXPECT_EQ(n, static_cast< ssize_t >(new_content.size()));
         ::close(fd);
     };
 

--- a/src/grpc/rpc_server.cpp
+++ b/src/grpc/rpc_server.cpp
@@ -87,6 +87,9 @@ void GrpcServer::run(const rpc_thread_start_cb_t& thread_start_cb) {
     LOGMSG_ASSERT_EQ(m_state.load(std::memory_order_relaxed), ServerState::INITED, "Grpcserver duplicate run?");
 
     m_server = m_builder.BuildAndStart();
+    if (!m_server) {
+        throw std::runtime_error("BuildAndStart failed — TLS config is invalid (partial or mismatched cert/key)");
+    }
 
     for (uint32_t i = 0; i < m_num_threads; ++i) {
         auto t = std::make_shared< std::thread >(&GrpcServer::handle_rpcs, this, i, thread_start_cb);

--- a/src/grpc/tests/unit/auth_test.cpp
+++ b/src/grpc/tests/unit/auth_test.cpp
@@ -13,6 +13,8 @@
  *
  *********************************************************************************/
 #include <memory>
+#include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <mutex>
@@ -449,6 +451,30 @@ TEST(GenericServiceDeathTest, basic_test) {
             validate_generic_reply(method, status);
         },
         1);
+}
+
+// Regression: GrpcServer::run() did not null-check the return value of BuildAndStart().
+// Passing invalid TLS credentials causes BuildAndStart() to return nullptr silently;
+// the null was stored in m_server with state set to RUNNING, deferring a crash to the
+// next shutdown() call. Verify that run() now throws instead.
+TEST(GrpcServerRunTest, throws_on_invalid_tls) {
+    namespace fs = std::filesystem;
+    const auto tmp_key = fs::temp_directory_path() / "test_invalid_grpc.key";
+    const auto tmp_cert = fs::temp_directory_path() / "test_invalid_grpc.cert";
+    {
+        std::ofstream k{tmp_key};
+        k << "not a valid PEM key\n";
+        std::ofstream c{tmp_cert};
+        c << "not a valid PEM cert\n";
+    }
+
+    auto* raw = sisl::GrpcServer::make("0.0.0.0:0", nullptr, 1, tmp_key.string(), tmp_cert.string());
+    ASSERT_NE(raw, nullptr);
+    auto server = std::unique_ptr< sisl::GrpcServer >(raw);
+    EXPECT_THROW(server->run(), std::runtime_error);
+
+    fs::remove(tmp_key);
+    fs::remove(tmp_cert);
 }
 
 } // namespace sisl::grpc::testing


### PR DESCRIPTION
## Problem

During TLS cert rotation, two bugs combined to crash access-mgr pods with SIGSEGV (confirmed in production):

**Bug 1 — FileWatcher stale filecontents cache.**  `on_modified_event()` read updated file contents into a local `FileInfo` copy but never wrote them back to `m_files`. Every subsequent `IN_MODIFY` compared against the original registered contents, treating each event as a content change and re-firing all callbacks. A single cert rotation produced 8 concurrent `spinupGrpcServer` calls (2 files × 2 stale-cache re-fires × 2 listeners).

**Bug 2 — `GrpcServer::run()` did not null-check `BuildAndStart()`.**  If the cert/key file is partially written at callback time, OpenSSL silently rejects the PEM and `BuildAndStart()` returns `nullptr`. The old code stored that null in `m_server` with state `RUNNING`, deferring a crash to the next `shutdown()` call via `m_server->Shutdown()` → SIGSEGV.

## Changes

- **`GrpcServer::run()`**: throw `std::runtime_error` if `BuildAndStart()` returns `nullptr`, before state is set to `RUNNING`. The zombie `GrpcServer` is then safely destroyed (`shutdown()` is a no-op in `INITED` state).
- **`FileWatcher::on_modified_event()`**: persist updated filecontents back to `m_files` under the map lock so subsequent `IN_MODIFY` events correctly detect no change and do not re-fire.
- **`FileWatcher::start(uint32_t debounce_ms = 200)`**: add a configurable quiet-period debounce. `IN_MODIFY` events now mark the file as pending; `poll()` uses a dynamic timeout; content is read and callbacks fire only after no new events arrive for `debounce_ms`. This closes the partial-write race for large files (e.g. real TLS certs written over multiple `write()` syscalls). Deletion events are still dispatched immediately. All existing call sites are source-compatible (default parameter).

## Tests

- `GrpcServerRunTest/throws_on_invalid_tls` — verifies `run()` throws on an invalid TLS cert/key pair rather than storing a null `m_server`.
- `FileWatcherTest/no_refire_on_repeated_write` — verifies that writing identical content a second time does not re-fire the change callback.