### PR TITLE
sisl/async: add stdexec scheduler primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [14.1.0] - 2026-05-10
+- Add header-only async building blocks for sender-driven storage code. cqe_state bridges io_uring CQEs to callback-owned operation state; io_uring_scheduler
+  exposes single-threaded schedule_at() and async_submit() senders on a caller-owned ring, batches submission in poll_once(), and flushes pending SQEs when the
+  ring is full.
+- Add manual_scheduler for deterministic virtual-time tests, wire the async test target behind an existing stdexec target, and cover timer ordering/past-
+  deadline behavior. stdexec stays consumer-provided, so the module can remain header-only until sisl owns that dependency.
+
+
 ## [14.0.1] - 2026-04-26
 - Suppress warnings on Release builds due to missing `;`
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=2.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "14.0.2"
+    version = "14.1.0"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/async/cqe_state.hpp
+++ b/include/sisl/async/cqe_state.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sisl::async {
+
+// Bit 63 of cqe->user_data marks "this CQE belongs to a sisl::async-aware
+// submitter that owns the user_data pointee." Canonical userspace addresses
+// on x86_64/ARM64 use <=48 bits, so bit 63 is always zero in any valid
+// pointer; the OR is safe and reversible.
+//
+// Sharing this contract across consumers (sisl's own callback cqe_state,
+// billet's stdexec sender op-state, ublkpp's coroutine-awaitable cqe_state,
+// future drivers, etc.) keeps user_data encoding consistent. A custom
+// dispatch loop can use the bit to separate "managed by this consumer" from
+// "delegate elsewhere" without baking any one consumer's type into the
+// encoding. io_uring_scheduler is narrower: every managed non-null CQE it
+// reaps must point at sisl::async::cqe_state.
+constexpr uint64_t k_managed_bit = 1ULL << 63;
+
+// Returns true if `ud` was produced by encode_managed_user_data, i.e. the
+// CQE belongs to a sisl::async-aware submitter. False means the CQE should
+// be delegated to whoever else shares the io_uring (ublksrv command path,
+// raw consumers, etc.).
+inline bool is_managed_user_data(uint64_t ud) noexcept {
+    return 0 != (ud & k_managed_bit);
+}
+
+// Encodes a pointer into a user_data value with the managed bit set.
+// Type-erased on purpose for custom dispatch loops: they may recover whatever
+// pointer type they own. io_uring_scheduler specifically encodes
+// sisl::async::cqe_state* and decodes managed non-null values as that type.
+inline uint64_t encode_managed_user_data(void* p) noexcept {
+    return reinterpret_cast< uint64_t >(p) | k_managed_bit;
+}
+
+// Strips the managed bit and returns the encoded pointer. Pre-condition:
+// is_managed_user_data(ud) is true. The result MAY be nullptr -- some
+// consumers use a managed-null sentinel (e.g. probe-timeout markers) that
+// must be distinguished from "not managed at all"; that is what the
+// is_managed_user_data check is for. If you only have a typed cqe_state
+// path and don't care about sentinels, treat managed-null and not-managed
+// as the same skip case.
+inline void* decode_managed_user_data(uint64_t ud) noexcept {
+    return reinterpret_cast< void* >(ud & ~k_managed_bit);
+}
+
+// Per-SQE bridge between an io_uring CQE and the consumer that submitted it.
+// Polymorphic via a function-pointer + opaque context: the dispatch loop
+// invokes _on_complete(_on_complete_ctx, cqe->res) when the matching CQE
+// arrives. Consumers wire this up however they like:
+//   - stdexec sender op-state: thunk calls stdexec::set_value(receiver).
+//   - C++20 coroutine awaitable bridge: thunk resumes a stored
+//     coroutine_handle (caller is responsible for exception discipline
+//     across resume() since completion_fn is noexcept).
+//   - Synchronous wait: thunk just sets a flag.
+//
+// _result and _result_ready are also written by the dispatch loop for
+// callers that want to peek without going through the callback path
+// (e.g., debug asserts, manual wait loops).
+//
+// Lifetime contract:
+//   - The cqe_state's address is stored in the SQE's user_data
+//     (encoded via encode_managed_user_data).
+//   - The owner MUST keep the cqe_state alive until the dispatch loop
+//     invokes the callback. The simplest pattern is to embed the
+//     cqe_state in the sender's operation_state, which lives until
+//     set_value fires.
+struct cqe_state {
+    using completion_fn = void (*)(void* ctx, int res) noexcept;
+
+    completion_fn _on_complete{nullptr};
+    void*         _on_complete_ctx{nullptr};
+    int           _result{0};
+    bool          _result_ready{false};
+};
+
+// Standard "I reaped a CQE for this state, deliver it" sequence. Used by
+// io_uring_scheduler::poll_once and intended to be used by any other
+// dispatch loop sharing the same io_uring (e.g. ublkpp's queue loop) so
+// the writes-then-callback ordering is identical across consumers.
+inline void complete_cqe_state(cqe_state& s, int res) noexcept {
+    s._result       = res;
+    s._result_ready = true;
+    if (nullptr != s._on_complete) { s._on_complete(s._on_complete_ctx, res); }
+}
+
+} // namespace sisl::async

--- a/include/sisl/async/io_uring_scheduler.hpp
+++ b/include/sisl/async/io_uring_scheduler.hpp
@@ -1,0 +1,242 @@
+#pragma once
+
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <system_error>
+#include <utility>
+
+#include <liburing.h>
+
+#include <stdexec/execution.hpp>
+
+#include <sisl/async/cqe_state.hpp>
+
+namespace sisl::async {
+
+// Single-threaded io_uring scheduler exposing stdexec senders. Submission,
+// polling, and continuation must all happen on the SAME thread (the
+// queue/worker thread that owns the io_uring). The scheduler does NOT own
+// the io_uring's lifetime -- the caller is responsible for queue_init and
+// queue_exit.
+//
+// Senders are returned directly (not wrapped in exec::task), so consumer
+// coroutines can `co_await sched.schedule_at(...)` from any sender-aware
+// coroutine (exec::task<T> in particular) without surprises from
+// as_awaitable / continues_on interposition.
+//
+// Usage (single-thread driver loop):
+//
+//   ::io_uring ring{};
+//   ::io_uring_queue_init(N, &ring, 0);
+//   sisl::async::io_uring_scheduler sched(&ring);
+//
+//   bool done = false;
+//   auto runner = [&]() -> exec::task<void> {
+//       co_await sched.schedule_at(target_ns);
+//       done = true;
+//   };
+//   exec::async_scope scope;
+//   scope.spawn(runner());
+//   while (!done) sched.poll_once(std::chrono::milliseconds{1});
+class io_uring_scheduler {
+public:
+    explicit io_uring_scheduler(::io_uring* ring) noexcept : _ring(ring) {}
+
+    io_uring_scheduler(io_uring_scheduler const&)            = delete;
+    io_uring_scheduler& operator=(io_uring_scheduler const&) = delete;
+
+    // ------- senders --------------------------------------------------------
+
+    // sender that completes with `void` after wall_ns wall time, backed by an
+    // IORING_OP_TIMEOUT SQE (IORING_TIMEOUT_ABS) on CLOCK_MONOTONIC. The
+    // wakeup arrives via the same CQE path as I/O completions.
+    [[nodiscard]] auto schedule_at(uint64_t wall_ns) noexcept {
+        return timeout_sender{_ring, wall_ns};
+    }
+
+    // sender that completes with `int` (cqe->res) after the SQE prepared by
+    // `prep` is reaped. PrepFn signature: void(io_uring_sqe*).
+    template < typename PrepFn >
+    [[nodiscard]] auto async_submit(PrepFn prep) noexcept {
+        return submit_sender< PrepFn >{_ring, std::move(prep)};
+    }
+
+    // ------- run loop -------------------------------------------------------
+
+    // Reap cycle. Called on the scheduler's owning thread in a loop:
+    //
+    //     while (!stop) sched.poll_once(std::chrono::milliseconds{1});
+    //
+    // Submits any SQEs queued since the last poll_once (op senders only
+    // call ::io_uring_get_sqe / set user_data; submission is deferred so
+    // many ops produced in a tight emission burst go through one
+    // syscall, not one each), then waits up to `wait_budget` for a CQE.
+    // wait_budget == 0 means non-blocking poll. Drains all currently-
+    // queued CQEs in one pass, invoking each cqe_state's completion
+    // thunk.
+    void poll_once(std::chrono::nanoseconds wait_budget) {
+        if (0 < wait_budget.count()) {
+            __kernel_timespec ts{};
+            ts.tv_sec  = static_cast< __kernel_time64_t >(wait_budget.count() / 1'000'000'000);
+            ts.tv_nsec = static_cast< long long >(wait_budget.count() % 1'000'000'000);
+            ::io_uring_cqe* unused = nullptr;
+            // Submits pending SQEs and waits for one CQE in a single
+            // syscall. The crucial perf piece: many op senders that
+            // queued SQEs since the last poll go out together.
+            (void)::io_uring_submit_and_wait_timeout(_ring, &unused, 1, &ts, nullptr);
+        } else {
+            // No wait, but still flush any pending SQEs.
+            (void)::io_uring_submit(_ring);
+        }
+
+        ::io_uring_cqe* cqe = nullptr;
+        unsigned head       = 0;
+        unsigned reaped     = 0;
+        io_uring_for_each_cqe(_ring, head, cqe) {
+            uint64_t const ud = ::io_uring_cqe_get_data64(cqe);
+            // Two-step decode: bit check first, then strip. This scheduler
+            // assumes it owns the ring, or at least that every managed
+            // non-null CQE it reaps points at sisl::async::cqe_state.
+            // Managed-null and non-managed CQEs are skipped here, but still
+            // consumed by cq_advance below; mixed-owner rings need a custom
+            // dispatch loop that delegates before advancing.
+            if (is_managed_user_data(ud)) {
+                auto* const state = static_cast< cqe_state* >(decode_managed_user_data(ud));
+                if (nullptr != state) { complete_cqe_state(*state, cqe->res); }
+            }
+            ++reaped;
+        }
+        if (0 < reaped) { ::io_uring_cq_advance(_ring, reaped); }
+    }
+
+    ::io_uring* ring() noexcept { return _ring; }
+
+private:
+    // ------- timeout_sender -------------------------------------------------
+
+    // Acquires an SQE from the ring, flushing any pending SQEs first if
+    // the ring is full. Returns nullptr only if the kernel cannot allocate
+    // one even after submission -- caller should treat as transient
+    // back-pressure. Same idiom as ublkpp's lib/cqe_state.hpp::next_sqe.
+    static ::io_uring_sqe* acquire_sqe(::io_uring* ring) noexcept {
+        ::io_uring_sqe* sqe = ::io_uring_get_sqe(ring);
+        if (nullptr != sqe) { return sqe; }
+        // Ring full: flush queued SQEs to make room. After a successful
+        // submit the SQ is empty and get_sqe returns a fresh slot.
+        if (0 > ::io_uring_submit(ring)) { return nullptr; }
+        return ::io_uring_get_sqe(ring);
+    }
+
+    template < typename Receiver >
+    struct timeout_op {
+        ::io_uring*       _ring;
+        uint64_t          _wall_ns;
+        Receiver          _receiver;
+        cqe_state         _state{};
+        __kernel_timespec _ts{};
+
+        void start() noexcept {
+            _ts.tv_sec  = static_cast< __kernel_time64_t >(_wall_ns / 1'000'000'000ULL);
+            _ts.tv_nsec = static_cast< long long >(_wall_ns % 1'000'000'000ULL);
+
+            _state._on_complete_ctx = this;
+            _state._on_complete     = +[](void* ctx, int /*res*/) noexcept {
+                auto* const self = static_cast< timeout_op* >(ctx);
+                stdexec::set_value(std::move(self->_receiver));
+            };
+
+            ::io_uring_sqe* const sqe = acquire_sqe(_ring);
+            if (nullptr == sqe) {
+                // Should be unreachable after the submit-on-full retry,
+                // but honesty matters: do NOT silently set_value() as if
+                // the timer fired. Surface through the error channel so
+                // a Poisson loop awaiting schedule_at sees a real error
+                // instead of waking early. The exec::task awaiting this
+                // sender rethrows the captured exception_ptr.
+                try {
+                    throw std::system_error{ENOMEM, std::system_category(),
+                                             "io_uring_scheduler: SQ exhausted on schedule_at"};
+                } catch (...) { stdexec::set_error(std::move(_receiver), std::current_exception()); }
+                return;
+            }
+            ::io_uring_prep_timeout(sqe, &_ts, 0, IORING_TIMEOUT_ABS);
+            ::io_uring_sqe_set_data64(sqe, encode_managed_user_data(&_state));
+            // Submission is DEFERRED to poll_once for batching. This is
+            // the difference between "syscall per op" and "syscall per
+            // poll cycle"; at QD=32 it's a ~30x cut in syscalls.
+        }
+    };
+
+    struct timeout_sender {
+        using sender_concept = stdexec::sender_t;
+        using completion_signatures =
+            stdexec::completion_signatures< stdexec::set_value_t(), stdexec::set_error_t(std::exception_ptr) >;
+
+        ::io_uring* _ring;
+        uint64_t    _wall_ns;
+
+        template < typename Receiver >
+        timeout_op< std::decay_t< Receiver > > connect(Receiver&& r) const noexcept {
+            return {_ring, _wall_ns, std::forward< Receiver >(r), {}, {}};
+        }
+    };
+
+    // ------- submit_sender --------------------------------------------------
+
+    template < typename PrepFn, typename Receiver >
+    struct submit_op {
+        ::io_uring* _ring;
+        PrepFn      _prep;
+        Receiver    _receiver;
+        cqe_state   _state{};
+
+        void start() noexcept {
+            _state._on_complete_ctx = this;
+            _state._on_complete     = +[](void* ctx, int res) noexcept {
+                auto* const self = static_cast< submit_op* >(ctx);
+                stdexec::set_value(std::move(self->_receiver), res);
+            };
+
+            ::io_uring_sqe* const sqe = acquire_sqe(_ring);
+            if (nullptr == sqe) {
+                // For async_submit the int value channel can carry a
+                // negative errno (mirroring cqe->res semantics), but a
+                // ring-full condition is a scheduler-level failure
+                // distinct from a kernel I/O error -- surface through
+                // the error channel so callers can distinguish.
+                try {
+                    throw std::system_error{ENOMEM, std::system_category(),
+                                             "io_uring_scheduler: SQ exhausted on async_submit"};
+                } catch (...) { stdexec::set_error(std::move(_receiver), std::current_exception()); }
+                return;
+            }
+            _prep(sqe);
+            ::io_uring_sqe_set_data64(sqe, encode_managed_user_data(&_state));
+        }
+    };
+
+    template < typename PrepFn >
+    struct submit_sender {
+        using sender_concept = stdexec::sender_t;
+        using completion_signatures =
+            stdexec::completion_signatures< stdexec::set_value_t(int), stdexec::set_error_t(std::exception_ptr) >;
+
+        ::io_uring* _ring;
+        PrepFn      _prep;
+
+        template < typename Receiver >
+        submit_op< PrepFn, std::decay_t< Receiver > > connect(Receiver&& r) && noexcept {
+            return {_ring, std::move(_prep), std::forward< Receiver >(r), {}};
+        }
+        template < typename Receiver >
+        submit_op< PrepFn, std::decay_t< Receiver > > connect(Receiver&& r) const& noexcept {
+            return {_ring, _prep, std::forward< Receiver >(r), {}};
+        }
+    };
+
+    ::io_uring* _ring;
+};
+
+} // namespace sisl::async

--- a/include/sisl/async/manual_scheduler.hpp
+++ b/include/sisl/async/manual_scheduler.hpp
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <cstdint>
+#include <queue>
+#include <utility>
+#include <vector>
+
+#include <stdexec/execution.hpp>
+
+namespace sisl::async {
+
+// Virtual-time scheduler for unit tests. Holds a monotonic ns counter that
+// only advances via explicit step() calls. schedule_at(ns) returns a stdexec
+// sender that completes when virtual time crosses the requested wall_ns,
+// which makes time-driven workloads (Poisson emitters, periodic
+// checkpointers, drain timeouts) deterministic in tests without sleeping
+// or running the io_uring CQE loop.
+//
+// Single-threaded by design: the test thread calls step() and the senders'
+// completions fire on that same thread inside step()'s drain pass.
+//
+// Pattern (test-side):
+//
+//     sisl::async::manual_scheduler sched;
+//     bool fired = false;
+//     auto runner = [&]() -> exec::task<void> {
+//         co_await sched.schedule_at(50'000'000);  // 50 ms virtual
+//         fired = true;
+//     };
+//     exec::async_scope scope;
+//     scope.spawn(runner());
+//     EXPECT_FALSE(fired);
+//     sched.step(std::chrono::milliseconds{49});
+//     EXPECT_FALSE(fired);                          // not yet
+//     sched.step(std::chrono::milliseconds{1});
+//     EXPECT_TRUE(fired);                           // crossed 50 ms
+class manual_scheduler {
+public:
+    manual_scheduler() = default;
+
+    manual_scheduler(manual_scheduler const&)            = delete;
+    manual_scheduler& operator=(manual_scheduler const&) = delete;
+
+    // Current virtual time in nanoseconds.
+    uint64_t now_ns() const noexcept { return _now; }
+
+    // Advance virtual time by `delta`, then fire every timer whose
+    // deadline is at or before the new time, in deadline order. Each
+    // fired timer's set_value runs on this thread inline.
+    template < typename Rep, typename Period >
+    void step(std::chrono::duration< Rep, Period > delta) {
+        _now += static_cast< uint64_t >(std::chrono::duration_cast< std::chrono::nanoseconds >(delta).count());
+        drain_expired();
+    }
+
+    // Drain any timers whose deadline is already in the past without
+    // advancing time. Useful when a test schedules a timer at "now" and
+    // wants to confirm it fires immediately.
+    void drain_expired() {
+        while (!_timers.empty() && _timers.top().deadline <= _now) {
+            entry const e = _timers.top();
+            _timers.pop();
+            e.fire(e.ctx);
+        }
+    }
+
+    // ----- timer sender -----
+
+    using fire_fn = void (*)(void*) noexcept;
+
+    template < typename Receiver >
+    struct timer_op {
+        manual_scheduler* _sched;
+        uint64_t          _deadline;
+        Receiver          _receiver;
+
+        void start() noexcept {
+            if (_deadline <= _sched->_now) {
+                stdexec::set_value(std::move(_receiver));
+                return;
+            }
+            _sched->_timers.push(entry{_deadline, &timer_op::fire_thunk, this});
+        }
+
+        static void fire_thunk(void* p) noexcept {
+            auto* const self = static_cast< timer_op* >(p);
+            stdexec::set_value(std::move(self->_receiver));
+        }
+    };
+
+    struct timer_sender {
+        using sender_concept        = stdexec::sender_t;
+        using completion_signatures = stdexec::completion_signatures< stdexec::set_value_t() >;
+
+        manual_scheduler* _sched;
+        uint64_t          _deadline;
+
+        template < typename Receiver >
+        timer_op< std::decay_t< Receiver > > connect(Receiver&& r) const noexcept {
+            return {_sched, _deadline, std::forward< Receiver >(r)};
+        }
+    };
+
+    [[nodiscard]] timer_sender schedule_at(uint64_t wall_ns) noexcept { return {this, wall_ns}; }
+
+private:
+    struct entry {
+        uint64_t deadline;
+        fire_fn  fire;
+        void*    ctx;
+        // Reverse order so std::priority_queue (default max-heap) acts
+        // like a min-heap on deadline.
+        bool operator<(entry const& o) const noexcept { return deadline > o.deadline; }
+    };
+
+    std::priority_queue< entry, std::vector< entry > > _timers;
+    uint64_t                                           _now{0};
+};
+
+} // namespace sisl::async

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(spdlog REQUIRED)
 find_package(zmarok-semver REQUIRED)
 find_package(breakpad)
 
+add_subdirectory(async)
 add_subdirectory(logging)
 add_subdirectory(options)
 add_subdirectory(sobject)

--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.11)
+
+# sisl_async is header-only; the tests below need stdexec available in
+# the sisl build. The wiring is up to the consumer (FetchContent in a
+# feature branch today, a Conan recipe later); this CMakeLists is
+# inert if stdexec hasn't been declared as a target yet.
+
+if (TARGET stdexec)
+    add_executable(test_manual_scheduler)
+    target_sources(test_manual_scheduler PRIVATE
+        tests/test_manual_scheduler.cpp
+    )
+    target_link_libraries(test_manual_scheduler PRIVATE
+        stdexec
+        GTest::gtest
+        GTest::gtest_main
+    )
+    add_test(NAME ManualScheduler COMMAND test_manual_scheduler)
+endif()

--- a/src/async/tests/test_manual_scheduler.cpp
+++ b/src/async/tests/test_manual_scheduler.cpp
@@ -1,0 +1,99 @@
+// Self-test for sisl::async::manual_scheduler. Validates that timer
+// senders fire only after virtual time crosses their deadline, in
+// deadline order, and that step() drains all expired timers in one pass.
+
+#include <chrono>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <exec/async_scope.hpp>
+#include <exec/task.hpp>
+#include <stdexec/execution.hpp>
+
+#include <sisl/async/manual_scheduler.hpp>
+
+namespace {
+
+TEST(manual_scheduler, step_below_deadline_does_not_fire) {
+    sisl::async::manual_scheduler sched;
+    bool                          fired  = false;
+    auto                          runner = [&]() -> exec::task< void > {
+        co_await sched.schedule_at(50'000'000);
+        fired = true;
+    };
+    exec::async_scope scope;
+    scope.spawn(runner());
+
+    sched.step(std::chrono::milliseconds{49});
+    EXPECT_FALSE(fired);
+    sched.step(std::chrono::milliseconds{1});
+    EXPECT_TRUE(fired);
+    stdexec::sync_wait(scope.on_empty());
+}
+
+TEST(manual_scheduler, step_past_deadline_fires_in_one_drain) {
+    sisl::async::manual_scheduler sched;
+    bool                          fired  = false;
+    auto                          runner = [&]() -> exec::task< void > {
+        co_await sched.schedule_at(50'000'000);
+        fired = true;
+    };
+    exec::async_scope scope;
+    scope.spawn(runner());
+
+    sched.step(std::chrono::milliseconds{500});
+    EXPECT_TRUE(fired);
+    EXPECT_EQ(500'000'000u, sched.now_ns());
+    stdexec::sync_wait(scope.on_empty());
+}
+
+TEST(manual_scheduler, multiple_timers_fire_in_deadline_order) {
+    sisl::async::manual_scheduler sched;
+    std::vector< int >            order;
+
+    auto schedule_one = [&](int label, uint64_t wall_ns) -> exec::task< void > {
+        co_await sched.schedule_at(wall_ns);
+        order.push_back(label);
+    };
+
+    exec::async_scope scope;
+    // Spawn out of deadline order on purpose; expect step to fire them
+    // in deadline order regardless of spawn order.
+    scope.spawn(schedule_one(/*label=*/3, 30'000'000));
+    scope.spawn(schedule_one(/*label=*/1, 10'000'000));
+    scope.spawn(schedule_one(/*label=*/2, 20'000'000));
+
+    sched.step(std::chrono::milliseconds{5});
+    EXPECT_TRUE(order.empty());
+
+    sched.step(std::chrono::milliseconds{15}); // now=20ms
+    ASSERT_EQ(2u, order.size());
+    EXPECT_EQ(1, order[0]);
+    EXPECT_EQ(2, order[1]);
+
+    sched.step(std::chrono::milliseconds{20}); // now=40ms
+    ASSERT_EQ(3u, order.size());
+    EXPECT_EQ(3, order[2]);
+    stdexec::sync_wait(scope.on_empty());
+}
+
+TEST(manual_scheduler, deadline_already_past_fires_immediately) {
+    sisl::async::manual_scheduler sched;
+    sched.step(std::chrono::milliseconds{100}); // now=100ms
+
+    bool fired  = false;
+    auto runner = [&]() -> exec::task< void > {
+        // Schedule a deadline that is already in the past.
+        co_await sched.schedule_at(50'000'000);
+        fired = true;
+    };
+    exec::async_scope scope;
+    scope.spawn(runner());
+
+    // No step() call: timer should fire on connect since deadline <= _now.
+    EXPECT_TRUE(fired);
+    stdexec::sync_wait(scope.on_empty());
+}
+
+} // namespace


### PR DESCRIPTION
Add header-only async building blocks for sender-driven storage code. cqe_state bridges io_uring CQEs to callback-owned operation state; io_uring_scheduler exposes single-threaded schedule_at() and async_submit() senders on a caller-owned ring, batches submission in poll_once(), and flushes pending SQEs when the ring is full.

Add manual_scheduler for deterministic virtual-time tests, wire the async test target behind an existing stdexec target, and cover timer ordering/past- deadline behavior. stdexec stays consumer-provided, so the module can remain header-only until sisl owns that dependency.