### PR TITLE
async: add stdexec coroutine primitives + gRPC coroutine reply path

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=2.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "14.3.1"
+    version = "14.4.0"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/async/task.hpp
+++ b/include/sisl/async/task.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+// The stack-wide coroutine/sender currency. sisl::async::task<T> is exec::task<T>
+// (stdexec). It is BOTH an awaitable (co_await from any coroutine) AND a sender
+// (composes with stdexec::when_all / when_any), which is what lets higher layers --
+// nuraft_mesg's AsyncResult, homestore's replication tasks -- gather async
+// operations (the collectAll/when_all fan-outs) on a single coroutine model.
+//
+// This header requires stdexec on the include path. sisl's own library targets do
+// NOT depend on stdexec; this is an opt-in header for consumers that have it (iomgr,
+// nuraft_mesg, homestore -- all co-built against the same stdexec). Lower-level sisl
+// bridges that must stay stdexec-free (e.g. the gRPC coroutine reply in
+// sisl/grpc/rpc_client.hpp) use sisl::async::value_awaitable instead and let a
+// consuming exec::task wrap them.
+
+#include <exec/task.hpp>
+
+namespace sisl::async {
+
+template < typename T >
+using task = exec::task< T >;
+
+} // namespace sisl::async

--- a/include/sisl/async/value_awaitable.hpp
+++ b/include/sisl/async/value_awaitable.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <atomic>
+#include <coroutine>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+namespace sisl::async {
+
+// Cross-thread, single-shot awaitable carrying a value of type T.
+//
+// Generalizes cqe_awaitable (cqe_state.hpp), which carries an int cqe->res, to an
+// arbitrary T -- for callback-style async completions whose result is a value
+// rather than a kernel return code (a gRPC unary response, a nuraft callback
+// result, etc.). The lock-free init/waiting/done handshake is identical: the
+// producer (any thread) calls complete(value); the consumer co_awaits. Whoever
+// runs second performs the single resume, restoring the cross-thread
+// happens-before that a std::future's shared state used to provide.
+//
+// THREAD SAFETY: the producer (complete) and the consumer (await_suspend) may run
+// on different threads. _result is published before the producer's release-exchange
+// and read after the consumer's matching acquire, so the value handoff is
+// race-free. The canonical example is a gRPC completion delivered on a worker
+// thread while the awaiting coroutine suspended on a reactor thread.
+//
+// LIFETIME: NON-MOVABLE -- the producer holds this object's address. Embed it in a
+// stable location and keep it alive until complete() has fired AND the consumer has
+// resumed past await_resume. Mirroring std::future's refcounted shared state, the
+// canonical pattern is to place it inside a std::shared_ptr held by BOTH the
+// producer op object and the consumer-facing awaitable handle; the producer object
+// can then be destroyed independently of the pending/just-resumed consumer.
+//
+// EXACTLY-ONCE: complete() must be called exactly once. await_resume moves the
+// value out, so the awaitable is single-shot.
+//
+// EXCEPTION DISCIPLINE: complete() is noexcept and calls _waiter.resume(); an
+// exception escaping the resumed frame therefore calls std::terminate (same
+// contract as cqe_awaitable::on_complete_thunk). A producer running on a noexcept
+// completion boundary must ensure the resumed coroutine body cannot throw across it.
+template < typename T >
+struct value_awaitable {
+    enum : uint8_t { k_init = 0, k_waiting = 1, k_done = 2 };
+
+    std::coroutine_handle<> _waiter{};
+    std::atomic< uint8_t > _state{k_init};
+    std::optional< T > _result{};
+
+    value_awaitable() = default;
+    value_awaitable(const value_awaitable&) = delete;
+    value_awaitable& operator=(const value_awaitable&) = delete;
+
+    // Producer side (any thread). Publishes the value, flips to done, and resumes
+    // the consumer iff it already suspended. The acq_rel exchange publishes _result
+    // across the thread boundary to a consumer that observes k_done.
+    void complete(T value) noexcept {
+        _result.emplace(std::move(value));
+        if (_state.exchange(k_done, std::memory_order_acq_rel) == k_waiting) { _waiter.resume(); }
+    }
+
+    // Fast path: skip suspension if the completion already arrived (acquire makes
+    // _result visible).
+    bool await_ready() const noexcept { return _state.load(std::memory_order_acquire) == k_done; }
+
+    // Returns true to stay suspended (the completer resumes us later); false to
+    // resume immediately because the completion landed between await_ready and here.
+    bool await_suspend(std::coroutine_handle<> h) noexcept {
+        _waiter = h;
+        return _state.exchange(k_waiting, std::memory_order_acq_rel) != k_done;
+    }
+
+    T await_resume() noexcept { return std::move(*_result); }
+};
+
+} // namespace sisl::async

--- a/include/sisl/async/when_all.hpp
+++ b/include/sisl/async/when_all.hpp
@@ -75,9 +75,8 @@ task< std::vector< T > > when_all(std::vector< task< T > > tasks) {
 
     auto latch = std::make_shared< detail::fan_latch >(n);
     for (std::size_t i = 0; i < n; ++i) {
-        stdexec::start_detached(stdexec::write_env(
-            detail::fan_run_one< T >(std::move(tasks[i]), results, i, latch),
-            stdexec::prop{stdexec::get_scheduler, exec::inline_scheduler{}}));
+        stdexec::start_detached(stdexec::write_env(detail::fan_run_one< T >(std::move(tasks[i]), results, i, latch),
+                                                   stdexec::prop{stdexec::get_scheduler, exec::inline_scheduler{}}));
     }
     co_await latch->_done;
     co_return std::move(*results);

--- a/include/sisl/async/when_all.hpp
+++ b/include/sisl/async/when_all.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+// Dynamic (runtime-sized) fan-out for sisl::async::task<T>.
+//
+// stdexec's when_all is variadic (compile-time arity); the replication/data paths fan out over a
+// runtime vector of peers (the collectAll/collectAllUnsafe sites). when_all() here starts every child
+// task concurrently and completes once all have finished, collecting their results by index.
+//
+// Built on the tested value_awaitable cross-thread handshake (a counting latch) + start_detached with
+// an inline scheduler -- the same pattern iomgr's drive launcher uses (io_launch.hpp): exec::task has
+// sticky scheduler affinity, so write_env injects exec::inline_scheduler to start a detached task that
+// resumes inline on whatever thread completes it.
+//
+// ERROR MODEL: errors-as-values. Each child task is expected to complete on its value channel with a T
+// (e.g. a Result<...> that may hold an error). when_all does NOT short-circuit on a child error (unlike
+// stdexec::when_all, which set_errors and cancels siblings) -- it always waits for every child, which is
+// what the "errors per-peer intentionally ignored" broadcasts require. Should a child throw, that slot
+// is left default-constructed (T must be default-constructible) and the fan-out still completes.
+//
+// THREADING: child continuations (and therefore the per-index result stores) run on whatever thread
+// completes each task -- for the gRPC path, a GrpcAsyncClientWorker thread. The counting latch publishes
+// a happens-before to the awaiting coroutine, so reading the result vector after the co_await is
+// race-free. Distinct indices are written by distinct children, so there is no aliasing on the vector.
+
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include <stdexec/execution.hpp>
+#include <exec/inline_scheduler.hpp>
+
+#include <sisl/async/task.hpp>
+#include <sisl/async/value_awaitable.hpp>
+
+namespace sisl::async {
+
+namespace detail {
+
+// N children count down once each; the awaitable fires when the last one does.
+struct fan_latch {
+    std::atomic< std::size_t > _count;
+    value_awaitable< std::monostate > _done;
+
+    explicit fan_latch(std::size_t n) noexcept : _count{n} {}
+
+    void count_down() noexcept {
+        if (_count.fetch_sub(1, std::memory_order_acq_rel) == 1) { _done.complete({}); }
+    }
+};
+
+// Void wrapper coroutine (cf. iomgr's drive_wrapper): awaits one child, stores its result by index, and
+// counts down. Swallows exceptions so the detached op never hits the set_error -> terminate path and so a
+// single failing child cannot strand the latch.
+template < typename T >
+task< void > fan_run_one(task< T > child, std::shared_ptr< std::vector< T > > results, std::size_t index,
+                         std::shared_ptr< fan_latch > latch) {
+    try {
+        (*results)[index] = co_await std::move(child);
+    } catch (...) {
+        // leave results[index] default-constructed
+    }
+    latch->count_down();
+}
+
+} // namespace detail
+
+// Start every task concurrently; complete once all have finished, returning results in input order.
+template < typename T >
+task< std::vector< T > > when_all(std::vector< task< T > > tasks) {
+    auto const n = tasks.size();
+    auto results = std::make_shared< std::vector< T > >(n);
+    if (n == 0) { co_return std::move(*results); }
+
+    auto latch = std::make_shared< detail::fan_latch >(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        stdexec::start_detached(stdexec::write_env(
+            detail::fan_run_one< T >(std::move(tasks[i]), results, i, latch),
+            stdexec::prop{stdexec::get_scheduler, exec::inline_scheduler{}}));
+    }
+    co_await latch->_done;
+    co_return std::move(*results);
+}
+
+} // namespace sisl::async

--- a/include/sisl/grpc/rpc_client.hpp
+++ b/include/sisl/grpc/rpc_client.hpp
@@ -37,6 +37,7 @@
 #include <sisl/utility/enum.hpp>
 #include <sisl/auth_manager/token_client.hpp>
 #include <sisl/fds/buffer.hpp>
+#include <sisl/async/value_awaitable.hpp>
 
 #include <fmt/format.h>
 
@@ -197,6 +198,47 @@ public:
 
 private:
     std::promise< GrpcResult< GenericClientResponse > > m_promise;
+};
+
+// ---- coroutine variant of the generic-unary future blob -------------------------
+//
+// Bridges a gRPC generic-unary completion to a co_await-able result WITHOUT a
+// std::future. The completion (delivered on a GrpcAsyncClientWorker thread) resolves
+// a sisl::async::value_awaitable; a consuming coroutine co_awaits it. The await state
+// lives in a refcounted shared block (like std::future's shared state) so the gRPC
+// data object can be deleted by client_loop while a still-pending or just-resumed
+// consumer keeps the result alive. Produced by GenericAsyncStub::call_unary_co().
+//
+// Intentionally only an awaitable, NOT a stdexec sender: the when_all fan-outs live a
+// layer up (over nuraft_mesg's exec::task results), so this leaf needs no stdexec and
+// keeps it out of this widely-included header. A consuming exec::task can co_await it.
+struct GenericRpcCoroState {
+    sisl::async::value_awaitable< GrpcResult< GenericClientResponse > > result;
+};
+using GenericRpcCoroStatePtr = std::shared_ptr< GenericRpcCoroState >;
+
+class GenericRpcDataCoroBlob : public ClientRpcDataInternal< grpc::ByteBuffer, grpc::ByteBuffer > {
+public:
+    explicit GenericRpcDataCoroBlob(GenericRpcCoroStatePtr state);
+    void handle_response([[maybe_unused]] bool ok = true) override;
+
+private:
+    GenericRpcCoroStatePtr m_state;
+};
+
+// Movable, co_await-able handle returned by GenericAsyncStub::call_unary_co().
+// co_await yields GrpcResult< GenericClientResponse >. Holds a ref to the shared await
+// state, so it stays valid across the gRPC data object's destruction.
+class GenericUnaryReply {
+public:
+    explicit GenericUnaryReply(GenericRpcCoroStatePtr state) noexcept : m_state{std::move(state)} {}
+
+    bool await_ready() const noexcept { return m_state->result.await_ready(); }
+    bool await_suspend(std::coroutine_handle<> h) noexcept { return m_state->result.await_suspend(h); }
+    GrpcResult< GenericClientResponse > await_resume() noexcept { return m_state->result.await_resume(); }
+
+private:
+    GenericRpcCoroStatePtr m_state;
 };
 
 template < typename ReqT, typename RespT >
@@ -475,6 +517,10 @@ public:
 
         GrpcAsyncResult< GenericClientResponse > call_unary(const io_blob_list_t& request, const std::string& method,
                                                             uint32_t deadline);
+
+        // Coroutine variant of the io_blob_list_t call_unary: returns a co_await-able reply instead of a
+        // std::future. Retained alongside the future overload during the coroutine migration.
+        GenericUnaryReply call_unary_co(const io_blob_list_t& request, const std::string& method, uint32_t deadline);
 
         std::unique_ptr< grpc::GenericStub > m_generic_stub;
         GrpcAsyncClientWorker* m_worker;

--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -11,6 +11,13 @@ target_sources(test_disk_task PRIVATE tests/test_disk_task.cpp)
 target_link_libraries(test_disk_task PRIVATE GTest::gtest GTest::gtest_main)
 add_test(NAME DiskTask COMMAND test_disk_task)
 
+# value_awaitable is header-only and stdexec-free (the cross-thread bridge primitive
+# behind sisl/grpc's coroutine reply); compile its tests unconditionally too.
+add_executable(test_value_awaitable)
+target_sources(test_value_awaitable PRIVATE tests/test_value_awaitable.cpp)
+target_link_libraries(test_value_awaitable PRIVATE GTest::gtest GTest::gtest_main)
+add_test(NAME ValueAwaitable COMMAND test_value_awaitable)
+
 if (TARGET stdexec)
     add_executable(test_cqe_awaitable)
     target_sources(test_cqe_awaitable PRIVATE

--- a/src/async/tests/test_value_awaitable.cpp
+++ b/src/async/tests/test_value_awaitable.cpp
@@ -1,0 +1,148 @@
+// Unit tests for sisl::async::value_awaitable<T> -- the cross-thread, value-carrying
+// generalization of cqe_awaitable used to bridge callback-style async completions
+// (gRPC unary responses, nuraft callback results) into a co_await.
+//
+// Mirrors test_cqe_awaitable.cpp: std::noop_coroutine() stands in for a suspended
+// coroutine's handle (no real frame), and the protocol is driven through the public
+// complete()/await_* API so both completion orderings are exercised deterministically.
+// No stdexec dependency -- these compile unconditionally like test_disk_task.
+
+#include <atomic>
+#include <coroutine>
+#include <expected>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <sisl/async/value_awaitable.hpp>
+
+namespace {
+
+using string_await = sisl::async::value_awaitable< std::string >;
+
+// ----------------------------------------------------------------------------
+// not-ready before completion
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, AwaitReadyFalseWhenNotReady) {
+    string_await state{};
+    EXPECT_FALSE(state.await_ready());
+    EXPECT_FALSE(state._waiter);
+}
+
+// ----------------------------------------------------------------------------
+// synchronous fast path: completion BEFORE the consumer co_awaits
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, CompleteThenAwaitReadyTrue) {
+    string_await state{};
+    state.complete("hello");
+    EXPECT_TRUE(state.await_ready()); // fast path: no suspension needed
+    EXPECT_EQ(state.await_resume(), "hello");
+}
+
+// ----------------------------------------------------------------------------
+// suspend-then-complete: consumer suspends first, completer resumes it.
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, SuspendThenCompleteResumesWaiter) {
+    string_await state{};
+
+    auto const h = std::noop_coroutine();
+    EXPECT_TRUE(state.await_suspend(h)); // not yet completed -> stay suspended
+    ASSERT_TRUE(state._waiter);
+
+    state.complete("world"); // fires the resume of the stored waiter (noop)
+    EXPECT_EQ(state.await_resume(), "world");
+}
+
+// ----------------------------------------------------------------------------
+// complete-then-suspend (the cross-thread race the atomic handshake fixes):
+// completion lands before await_suspend installs the waiter; the wakeup must not
+// be lost -- await_suspend returns false so the coroutine resumes immediately.
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, CompleteThenSuspendDoesNotSuspend) {
+    string_await state{};
+
+    state.complete("early"); // completer ran first
+
+    auto const h = std::noop_coroutine();
+    EXPECT_FALSE(state.await_suspend(h)); // do not suspend; result already available
+    EXPECT_EQ(state.await_resume(), "early");
+}
+
+// ----------------------------------------------------------------------------
+// value carriage: move-only payload survives the round trip
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, MoveOnlyValueRoundTrips) {
+    sisl::async::value_awaitable< std::unique_ptr< int > > state{};
+    state.complete(std::make_unique< int >(123));
+    ASSERT_TRUE(state.await_ready());
+    auto p = state.await_resume();
+    ASSERT_TRUE(p);
+    EXPECT_EQ(*p, 123);
+}
+
+// ----------------------------------------------------------------------------
+// expected-shaped payload (the GrpcResult shape: value or error)
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, ExpectedErrorRoundTrips) {
+    sisl::async::value_awaitable< std::expected< std::string, int > > state{};
+    state.complete(std::unexpected(42));
+    ASSERT_TRUE(state.await_ready());
+    auto r = state.await_resume();
+    ASSERT_FALSE(r.has_value());
+    EXPECT_EQ(r.error(), 42);
+}
+
+// ----------------------------------------------------------------------------
+// refcounted shared state: the producer object is destroyed (as client_loop does
+// after handle_response) while the consumer-facing handle keeps the result alive.
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, SharedStateSurvivesProducerDestruction) {
+    auto state = std::make_shared< string_await >();
+
+    // Producer side completes, then drops its ref (mimics client_loop `delete data`).
+    {
+        auto producer_ref = state;
+        producer_ref->complete("persisted");
+    }
+    ASSERT_EQ(state.use_count(), 1); // only the consumer-facing ref remains
+
+    EXPECT_TRUE(state->await_ready());
+    EXPECT_EQ(state->await_resume(), "persisted");
+}
+
+// ----------------------------------------------------------------------------
+// Cross-thread handshake: one thread installs the waiter (await_suspend) while
+// another delivers the completion (complete). Exactly one resume happens and the
+// value is observed without a data race. Run under TSAN to catch ordering
+// regressions in the lock-free handshake.
+// ----------------------------------------------------------------------------
+
+TEST(value_awaitable, CrossThreadHandshakeIsRaceFree) {
+    constexpr int kIters = 2000;
+    for (int i = 0; i < kIters; ++i) {
+        string_await state{};
+        std::atomic< bool > go{false};
+        std::thread completer([&] {
+            while (!go.load(std::memory_order_acquire)) {}
+            state.complete(std::to_string(i));
+        });
+
+        go.store(true, std::memory_order_release);
+        // Consumer races the completer: install the waiter (noop stands in for a frame).
+        (void)state.await_suspend(std::noop_coroutine());
+
+        completer.join(); // join publishes the completer's writes to this thread
+        EXPECT_EQ(state.await_resume(), std::to_string(i));
+    }
+}
+
+} // namespace

--- a/src/grpc/rpc_client.cpp
+++ b/src/grpc/rpc_client.cpp
@@ -189,6 +189,20 @@ GrpcAsyncResult< GenericClientResponse > GrpcAsyncClient::GenericAsyncStub::call
     return sf;
 }
 
+GenericUnaryReply GrpcAsyncClient::GenericAsyncStub::call_unary_co(const io_blob_list_t& request,
+                                                                   const std::string& method, uint32_t deadline) {
+    // Refcounted shared await state: held by both the gRPC data object (released when
+    // client_loop deletes it after handle_response) and the returned reply handle, so
+    // the result survives the data object's destruction -- the coroutine analog of the
+    // future overload's promise/future shared state.
+    auto state = std::make_shared< GenericRpcCoroState >();
+    auto data = new GenericRpcDataCoroBlob(state);
+    grpc::ByteBuffer cli_byte_buf;
+    serialize_to_byte_buffer(request, cli_byte_buf);
+    prepare_and_send_unary_generic(data, cli_byte_buf, method, deadline);
+    return GenericUnaryReply{std::move(state)};
+}
+
 std::unique_ptr< GrpcAsyncClient::GenericAsyncStub > GrpcAsyncClient::make_generic_stub(const std::string& worker) {
     auto w = GrpcAsyncClientWorker::get_worker(worker);
     if (w == nullptr) { throw std::runtime_error("worker thread not available"); }
@@ -241,6 +255,19 @@ void GenericRpcDataFutureBlob::handle_response([[maybe_unused]] bool ok) {
         m_promise.set_value(std::move(future_resp));
     } else {
         m_promise.set_value(std::unexpected(this->m_status));
+    }
+}
+
+GenericRpcDataCoroBlob::GenericRpcDataCoroBlob(GenericRpcCoroStatePtr state) : m_state{std::move(state)} {}
+
+void GenericRpcDataCoroBlob::handle_response([[maybe_unused]] bool ok) {
+    // For unary call, ok is always true, `status_` will indicate error if there are any.
+    // Resolve the shared await state; this resumes a suspended consumer coroutine (possibly on
+    // this gRPC worker thread). The state outlives `delete this` in client_loop via its shared_ptr.
+    if (this->m_status.ok()) {
+        m_state->result.complete(GenericClientResponse(this->m_reply));
+    } else {
+        m_state->result.complete(std::unexpected(this->m_status));
     }
 }
 


### PR DESCRIPTION
- async/value_awaitable.hpp: cross-thread single-shot awaitable carrying T (generalizes cqe_awaitable from int->T). Producer complete(T) from any thread, consumer co_awaits; same lock-free init/waiting/done acq_rel handshake that restores folly::Future's cross-thread happens-before.
- async/task.hpp: `using task = exec::task<T>` currency alias (opt-in header; needs stdexec).
- async/when_all.hpp: dynamic (runtime-vector) fan-out when_all(vector<task<T>>) -> task<vector<T>>. Counting latch on value_awaitable; errors-as-values, never short-circuits (broadcast semantics ignore per-peer errors). T must be default-constructible.
- grpc/rpc_client: GenericRpcDataCoroBlob + GenericAsyncStub::call_unary_co deliver a coroutine reply ALONGSIDE the std::future one (value_awaitable.complete fires from the gRPC CQ worker thread). Stays stdexec-free; when_all composition lives a layer up at nuraft_mesg.