### PR TITLE
Fix Named* metric index race and get_local_ips() segfault (v14.8.1)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "14.8.0"
+    version = "14.8.1"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/metrics/metrics.hpp
+++ b/include/sisl/metrics/metrics.hpp
@@ -162,15 +162,20 @@ public:
         return instance;
     }
 
-    void set_index(const uint64_t index) { m_Index = index; }
-    [[nodiscard]] uint64_t get_index() const { return m_Index; }
+    void set_index(const uint64_t index) { m_Index.store(index, std::memory_order_relaxed); }
+    [[nodiscard]] uint64_t get_index() const { return m_Index.load(std::memory_order_relaxed); }
     [[nodiscard]] constexpr const char* get_name() const { return m_Name; }
 
 private:
     NamedCounter() : m_Index{std::numeric_limits< uint64_t >::max()} {}
 
     static constexpr char m_Name[sizeof...(elements) + 1] = {elements..., '\0'};
-    uint64_t m_Index;
+
+    // Every instance of a group re-registers into this global singleton, so set_index races with the
+    // get_index() on the metric update path. Each registration writes the same index, and the index only
+    // ever selects a slot in the caller's own already-constructed group instance, so nothing is published
+    // through it -- relaxed is sufficient, and costs nothing over a plain load/store.
+    std::atomic< uint64_t > m_Index;
 };
 
 template < char... elements >
@@ -186,15 +191,17 @@ public:
         return instance;
     }
 
-    void set_index(const uint64_t index) { m_Index = index; }
-    [[nodiscard]] uint64_t get_index() const { return m_Index; }
+    void set_index(const uint64_t index) { m_Index.store(index, std::memory_order_relaxed); }
+    [[nodiscard]] uint64_t get_index() const { return m_Index.load(std::memory_order_relaxed); }
     [[nodiscard]] constexpr const char* get_name() const { return m_Name; }
 
 private:
     NamedGauge() : m_Index{std::numeric_limits< uint64_t >::max()} {}
 
     static constexpr char m_Name[sizeof...(elements) + 1] = {elements..., '\0'};
-    uint64_t m_Index;
+
+    // See the ordering note in NamedCounter::m_Index.
+    std::atomic< uint64_t > m_Index;
 };
 
 template < char... elements >
@@ -210,15 +217,17 @@ public:
         return instance;
     }
 
-    void set_index(const uint64_t index) { m_Index = index; }
-    [[nodiscard]] uint64_t get_index() const { return m_Index; }
+    void set_index(const uint64_t index) { m_Index.store(index, std::memory_order_relaxed); }
+    [[nodiscard]] uint64_t get_index() const { return m_Index.load(std::memory_order_relaxed); }
     [[nodiscard]] constexpr const char* get_name() const { return m_Name; }
 
 private:
     NamedHistogram() : m_Index{std::numeric_limits< uint64_t >::max()} {}
 
     static constexpr char m_Name[sizeof...(elements) + 1] = {elements..., '\0'};
-    uint64_t m_Index;
+
+    // See the ordering note in NamedCounter::m_Index.
+    std::atomic< uint64_t > m_Index;
 };
 
 // decltype(BOOST_PP_CAT(BOOST_PP_STRINGIZE(name), _tstr)

--- a/src/http/http_server.cpp
+++ b/src/http/http_server.cpp
@@ -198,15 +198,23 @@ bool HttpServer::auth_verify(httplib::Request const& req, httplib::Response& res
     return false;
 }
 
+// Split out of get_local_ips() so tests can feed a synthetic interface list: whether a host actually has
+// an address-less interface is not something a test can arrange.
+void collect_local_ipv4_addrs(struct ifaddrs* interfaces, std::unordered_set< std::string >& out) {
+    for (auto* addr = interfaces; addr != nullptr; addr = addr->ifa_next) {
+        // getifaddrs(3) leaves ifa_addr null for interfaces with no assigned address (tunnels, ppp).
+        if (addr->ifa_addr == nullptr) { continue; }
+        if (addr->ifa_addr->sa_family == AF_INET) {
+            out.emplace(inet_ntoa(((struct sockaddr_in*)addr->ifa_addr)->sin_addr));
+        }
+    }
+}
+
 void HttpServer::get_local_ips() {
     struct ifaddrs* interfaces = nullptr;
     auto error = getifaddrs(&interfaces);
     if (error != 0) { LOGWARN("getifaddrs returned non zero code: {}", error); }
-    for (auto* addr = interfaces; addr != nullptr; addr = addr->ifa_next) {
-        if (addr->ifa_addr->sa_family == AF_INET) {
-            m_local_ips.emplace(inet_ntoa(((struct sockaddr_in*)addr->ifa_addr)->sin_addr));
-        }
-    }
+    collect_local_ipv4_addrs(interfaces, m_local_ips);
     freeifaddrs(interfaces);
 }
 

--- a/src/http/tests/test_http_server.cpp
+++ b/src/http/tests/test_http_server.cpp
@@ -1,4 +1,5 @@
 #include <arpa/inet.h>
+#include <ifaddrs.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -8,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <unordered_set>
 
 #include <gtest/gtest.h>
 
@@ -93,6 +95,55 @@ public:
 void ok_handler(httplib::Request const&, httplib::Response& res) { res.set_content("ok", "text/plain"); }
 
 } // namespace
+
+// ---- Local IP discovery ----
+
+namespace sisl {
+// Defined in http_server.cpp; declared here rather than in the public header so <ifaddrs.h> stays out of
+// sisl/http/http_server.hpp.
+void collect_local_ipv4_addrs(struct ifaddrs* interfaces, std::unordered_set< std::string >& out);
+} // namespace sisl
+
+// getifaddrs(3) returns a null ifa_addr for interfaces with no assigned address -- a VPN or tunnel, say.
+// Dereferencing it unconditionally segfaulted every HttpServer constructor on such a host, which no CI
+// runner reproduces because lo/eth0 always carry an address. Hence the synthetic list.
+TEST(HttpServer, LocalIpsSkipNullIfaddr) {
+    struct sockaddr_in v4{};
+    v4.sin_family = AF_INET;
+    ASSERT_EQ(::inet_pton(AF_INET, "10.1.2.3", &v4.sin_addr), 1);
+
+    struct sockaddr_in6 v6{};
+    v6.sin6_family = AF_INET6;
+
+    char tun_name[]{"tun0"}, eth_name[]{"eth0"}, v6_name[]{"eth1"};
+
+    struct ifaddrs v6_if{};
+    v6_if.ifa_name = v6_name;
+    v6_if.ifa_addr = reinterpret_cast< struct sockaddr* >(&v6);
+    v6_if.ifa_next = nullptr;
+
+    struct ifaddrs v4_if{};
+    v4_if.ifa_name = eth_name;
+    v4_if.ifa_addr = reinterpret_cast< struct sockaddr* >(&v4);
+    v4_if.ifa_next = &v6_if;
+
+    struct ifaddrs tun_if{}; // address-less interface: the one that used to crash
+    tun_if.ifa_name = tun_name;
+    tun_if.ifa_addr = nullptr;
+    tun_if.ifa_next = &v4_if;
+
+    std::unordered_set< std::string > ips;
+    sisl::collect_local_ipv4_addrs(&tun_if, ips);
+
+    EXPECT_EQ(ips.size(), 1u);
+    EXPECT_EQ(ips.count("10.1.2.3"), 1u);
+}
+
+TEST(HttpServer, LocalIpsEmptyList) {
+    std::unordered_set< std::string > ips;
+    sisl::collect_local_ipv4_addrs(nullptr, ips);
+    EXPECT_TRUE(ips.empty());
+}
 
 // ---- URL classification (no server start needed) ----
 

--- a/src/metrics/CMakeLists.txt
+++ b/src/metrics/CMakeLists.txt
@@ -33,6 +33,13 @@ if(BUILD_TESTING)
     target_link_libraries(metrics_wrapper_test sisl_metrics GTest::gtest)
     add_test(NAME MetricsWrapper COMMAND metrics_wrapper_test)
 
+    add_executable(metrics_registration_race_test)
+    target_sources(metrics_registration_race_test PRIVATE
+        tests/registration_race_test.cpp
+      )
+    target_link_libraries(metrics_registration_race_test sisl_metrics GTest::gtest)
+    add_test(NAME MetricsRegistrationRace COMMAND metrics_registration_race_test)
+
     add_executable(metrics_benchmark)
     target_sources(metrics_benchmark PRIVATE
         tests/metrics_benchmark.cpp

--- a/src/metrics/tests/registration_race_test.cpp
+++ b/src/metrics/tests/registration_race_test.cpp
@@ -1,0 +1,113 @@
+/*********************************************************************************
+ * Modifications Copyright 2017-2019 eBay Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *********************************************************************************/
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <sisl/options/options.h>
+
+#include "sisl/metrics/metrics.hpp"
+
+SISL_LOGGING_INIT(vmod_metrics_framework)
+
+RCU_REGISTER_INIT
+
+using namespace sisl;
+
+namespace {
+
+// Shaped after sisl::StreamTrackerMetrics: one group instance per tracked object, so new instances keep
+// registering while earlier ones are still being updated. group_impl_type_t::atomic keeps the value
+// storage itself trivially race-free, so the only shared state under test is the Named* singletons.
+class ReplicaMetrics : public MetricsGroup {
+public:
+    explicit ReplicaMetrics(const std::string& inst_name) :
+            MetricsGroup("Replica", inst_name, group_impl_type_t::atomic) {
+        REGISTER_COUNTER(replica_updates, "Updates applied to this replica");
+        REGISTER_COUNTER(replica_conflicts, "Conflicting updates rejected");
+        REGISTER_GAUGE(replica_queue_depth, "Current replication queue depth");
+        REGISTER_HISTOGRAM(replica_apply_latency, "Update apply latency");
+
+        register_me_to_farm();
+    }
+    ~ReplicaMetrics() { deregister_me_from_farm(); }
+};
+
+constexpr size_t REGISTRAR_THREADS{4};
+constexpr size_t INSTANCES_PER_REGISTRAR{20};
+
+} // namespace
+
+// REGISTER_* writes the global NamedCounter/NamedGauge/NamedHistogram<name> singletons through
+// set_index(), while COUNTER_INCREMENT and friends read them through get_index() under no lock. Building
+// a second instance of a group on one thread while another thread updates an existing instance therefore
+// races on those globals -- the shape craft_client hits when it builds a replica's route map. Every
+// registration writes the same index, so the values stay correct; this asserts that invariant directly,
+// and under TSAN it fails on the race itself.
+TEST(MetricsRegistrationRace, ConcurrentRegistrationWhileUpdating) {
+    ReplicaMetrics first{"replica_0"};
+
+    const auto counter_idx{COUNTER_INDEX(replica_updates)};
+    const auto gauge_idx{GAUGE_INDEX(replica_queue_depth)};
+    const auto hist_idx{HISTOGRAM_INDEX(replica_apply_latency)};
+
+    std::atomic< bool > stop{false};
+    std::atomic< uint64_t > mismatches{0};
+
+    std::thread updater{[&stop, &mismatches, &first, counter_idx, gauge_idx, hist_idx]() {
+        while (!stop.load(std::memory_order_relaxed)) {
+            COUNTER_INCREMENT(first, replica_updates, 1);
+            GAUGE_UPDATE(first, replica_queue_depth, 1);
+            HISTOGRAM_OBSERVE(first, replica_apply_latency, 1);
+
+            if ((COUNTER_INDEX(replica_updates) != counter_idx) || (GAUGE_INDEX(replica_queue_depth) != gauge_idx) ||
+                (HISTOGRAM_INDEX(replica_apply_latency) != hist_idx)) {
+                mismatches.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    }};
+
+    // Each registrar owns its own slot in a pre-sized container, so the container is never contended.
+    std::vector< std::vector< std::unique_ptr< ReplicaMetrics > > > held(REGISTRAR_THREADS);
+    std::vector< std::thread > registrars;
+    for (size_t t{0}; t < REGISTRAR_THREADS; ++t) {
+        registrars.emplace_back([&held, t]() {
+            for (size_t i{0}; i < INSTANCES_PER_REGISTRAR; ++i) {
+                held[t].emplace_back(
+                    std::make_unique< ReplicaMetrics >("replica_" + std::to_string(t) + "_" + std::to_string(i)));
+            }
+        });
+    }
+
+    for (auto& r : registrars) {
+        r.join();
+    }
+    stop.store(true, std::memory_order_relaxed);
+    updater.join();
+
+    // Instances are destroyed only after every join, so deregistration cannot pollute the TSAN report.
+    EXPECT_EQ(mismatches.load(std::memory_order_relaxed), 0u);
+    EXPECT_GT(COUNTER_VALUE(first, replica_updates), 0);
+}
+
+SISL_OPTIONS_ENABLE(logging)
+int main(int argc, char* argv[]) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
* metrics: give the Named* metric index the atomicity its role requires

NamedCounter<name>, NamedGauge<name> and NamedHistogram<name> are global Meyers singletons keyed only by the metric name, each holding a plain uint64_t m_Index. REGISTER_COUNTER writes it through set_index() from every MetricsGroup subclass constructor; COUNTER_INCREMENT and friends read it through get_index() on the update path under no lock. Constructing a second instance of a group therefore writes a global that an in-flight update is reading, and nothing orders the two: MetricsGroupImpl's ctor holds m_static_info->m_mutex and MetricsFarm::register_metrics_group holds the farm lock, but the reader takes neither.

This is reachable today. StreamTracker holds a StreamTrackerMetrics member, so every new StreamTracker re-registers those globals while do_update() reads them -- the shape craft_client hits building a replica's route map, and the reason it carries a race:sisl::NamedCounter suppression.

The write is idempotent: m_static_info->m_reg_pending is true only for the first instance of a group, and later instances re-derive idx from m_counters_dinfo.size(), so the same name in the same group always lands at the same index. The observed value is therefore always correct -- the suppression's "benign" claim holds. But an unsynchronized write/read of a plain uint64_t is still a data race and still UB, and the idempotence only holds incidentally, because metric names happen to be group-prefixed. Nothing enforces it.

Make m_Index a relaxed std::atomic<uint64_t>. Relaxed is sufficient because nothing is published through the index: it only ever selects a slot in the caller's own group instance, whose construction already happens-before any use of it by the thread that owns it. On x86-64 the codegen is byte-for-byte identical (the load is a plain movq, no fence, no lock prefix), so this costs nothing on the hot path -- verified by diffing the -O2 assembly of COUNTER_INDEX before and after.

Adds MetricsRegistrationRace, which updates one instance while four threads register new instances of the same group. That is the gap no existing test covered: wrapper_test builds several instances of a group but on one thread, and farm_test is multi-threaded but its two groups use disjoint metric names, so no singleton is ever shared across threads. The test also asserts the index never changes, so it keeps enforcing the idempotence invariant in non-TSAN builds. Verified under TSAN: the race reports on 10/10 runs without the fix, 0/10 with it.

* http: skip interfaces with no address in get_local_ips()

getifaddrs(3) documents that ifa_addr may be a null pointer: it is null for interfaces with no assigned address, such as a VPN, tunnel or ppp link. get_local_ips() dereferenced addr->ifa_addr->sa_family unconditionally, so every HttpServer constructor segfaulted on any host with such an interface.

No CI runner reproduces it -- lo and eth0 always carry an address -- but a workstation with a VPN up does, which is where it surfaced.

Skip those entries. The iteration moves into collect_local_ipv4_addrs() so a test can feed a synthetic interface list, since whether the host has an address-less interface is not something a test can arrange. LocalIpsSkipNullIfaddr covers the null entry deterministically on any host; it segfaults without the guard.