### PR TITLE
SDSTOR-24888: Add inject_auth_metadata helper to GrpcSyncClient

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -10,7 +10,7 @@ required_conan_version = ">=2.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "14.8.1"
+    version = "14.8.2"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/grpc/rpc_client.hpp
+++ b/include/sisl/grpc/rpc_client.hpp
@@ -299,6 +299,11 @@ public:
     std::unique_ptr< typename ServiceT::StubInterface > MakeStub() {
         return ServiceT::NewStub(m_channel);
     }
+
+protected:
+    void inject_auth_metadata(::grpc::ClientContext& ctx) const {
+        if (m_token_client) { ctx.AddMetadata(m_token_client->get_auth_header_key(), m_token_client->get_token()); }
+    }
 };
 
 ENUM(ClientState, uint8_t, VOID, INIT, RUNNING, SHUTTING_DOWN, TERMINATED)

--- a/src/grpc/tests/unit/auth_test.cpp
+++ b/src/grpc/tests/unit/auth_test.cpp
@@ -357,7 +357,7 @@ TEST_F(AuthEnableTest, sync_client_injects_auth_header) {
     EchoReply reply;
     req.set_message("sync_inject_auth");
     ::grpc::Status status = sync_client.call_echo(req, reply);
-    EXPECT_TRUE(status.ok());
+    ASSERT_TRUE(status.ok()) << status.error_message();
     EXPECT_EQ(req.message(), reply.message());
 }
 

--- a/src/grpc/tests/unit/auth_test.cpp
+++ b/src/grpc/tests/unit/auth_test.cpp
@@ -326,6 +326,13 @@ public:
 
     const std::unique_ptr< EchoService::StubInterface >& echo_stub() { return echo_stub_; }
 
+    // Simulates how a real sync client subclass uses inject_auth_metadata (analogous to OmClient::init_ctx).
+    ::grpc::Status call_echo(const EchoRequest& req, EchoReply& reply) {
+        ::grpc::ClientContext ctx;
+        inject_auth_metadata(ctx);
+        return echo_stub_->Echo(&ctx, req, &reply);
+    }
+
 private:
     std::unique_ptr< EchoService::StubInterface > echo_stub_;
 };
@@ -341,6 +348,28 @@ TEST_F(AuthEnableTest, allow_sync_client_with_auth) {
     auto status = sync_client->echo_stub()->Echo(&context, req, &reply);
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(req.message(), reply.message());
+}
+
+TEST_F(AuthEnableTest, sync_client_injects_auth_header) {
+    EchoAndPingClient sync_client{grpc_server_addr, m_token_client, "", ""};
+    sync_client.init();
+    EchoRequest req;
+    EchoReply reply;
+    req.set_message("sync_inject_auth");
+    ::grpc::Status status = sync_client.call_echo(req, reply);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(req.message(), reply.message());
+}
+
+TEST_F(AuthServerOnlyTest, sync_client_no_token_is_noop) {
+    EchoAndPingClient sync_client{grpc_server_addr, "", ""};
+    sync_client.init();
+    EchoRequest req;
+    EchoReply reply;
+    req.set_message("sync_no_token");
+    ::grpc::Status status = sync_client.call_echo(req, reply);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.error_code(), ::grpc::UNAUTHENTICATED);
 }
 
 void validate_generic_reply(const std::string& method, ::grpc::Status& status) {


### PR DESCRIPTION
## Summary

- `GrpcSyncClient` had no way for subclasses to inject auth metadata into
  sync RPC contexts, even when a `GrpcTokenClient` was present on the base class
- Added `protected inject_auth_metadata(grpc::ClientContext&) const` that reads
  from the inherited `m_token_client`; no-ops silently when token client is null
- `GrpcAsyncClient` already had an equivalent inline auth injection; this closes
  the gap for sync clients

## Motivation

`OmClient` (block_mgr) uses `GrpcSyncClient` for BM→OM registration and
heartbeat RPCs. OM in cluster 117 has `grpc_auth_enable = 1` / `auth_mode = 1`.
BMs were being rejected by OM because every sync call arrived with no
`Authorization` header — `m_token_client` was populated but `get_token()` was
never called. This single-method addition fixes that without any API break.
