### PR TITLE
Fix histogram overflow bucket accounting

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=2.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "13.2.12"
+    version = "13.2.13"
 
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"

--- a/include/sisl/metrics/histogram_buckets.hpp
+++ b/include/sisl/metrics/histogram_buckets.hpp
@@ -79,6 +79,8 @@ public:
     HistogramBuckets(const HistogramBuckets&) = delete;
     void operator=(const HistogramBuckets&) = delete;
 
+    static size_t num_buckets(const hist_bucket_boundaries_t& boundaries) { return boundaries.size() + 1; }
+
 #define X(name, ...) _hist_bkt_count(__VA_ARGS__),
     static const constexpr size_t max_hist_bkts =
         _get_max_hist_bkts(HIST_BKTS_TYPES 0UL) + 1; // +1 for upper bound bucket

--- a/include/sisl/metrics/metrics_atomic.hpp
+++ b/include/sisl/metrics/metrics_atomic.hpp
@@ -61,11 +61,9 @@ public:
 
     void observe(const int64_t value, const hist_bucket_boundaries_t& boundaries, const uint64_t count = 1) {
         const auto lower{std::lower_bound(std::cbegin(boundaries), std::cend(boundaries), value)};
-        if (lower != std::cend(boundaries)) {
-            const auto bkt_idx{std::distance(std::cbegin(boundaries), lower)};
-            m_freqs[bkt_idx].fetch_add(count, std::memory_order_relaxed);
-            m_sum.fetch_add((value * count), std::memory_order_relaxed);
-        }
+        const auto bkt_idx{std::distance(std::cbegin(boundaries), lower)};
+        m_freqs[bkt_idx].fetch_add(count, std::memory_order_relaxed);
+        m_sum.fetch_add((value * count), std::memory_order_relaxed);
     }
 
     [[nodiscard]] auto& get_freqs() const { return m_freqs; }

--- a/include/sisl/metrics/metrics_group_impl.hpp
+++ b/include/sisl/metrics/metrics_group_impl.hpp
@@ -222,7 +222,7 @@ public:
     }
 
     void merge(const HistogramValue& other, const hist_bucket_boundaries_t& boundaries) {
-        for (size_t i{0}; i < boundaries.size(); ++i) {
+        for (size_t i{0}; i < HistogramBuckets::num_buckets(boundaries); ++i) {
             this->m_freqs[i] += other.m_freqs[i];
         }
         this->m_sum += other.m_sum;

--- a/src/metrics/metrics_group_impl.cpp
+++ b/src/metrics/metrics_group_impl.cpp
@@ -348,6 +348,9 @@ HistogramStaticInfo::HistogramStaticInfo(const std::string& name, const std::str
                                          const std::string& report_name, const metric_label& label_pair,
                                          const hist_bucket_boundaries_t& bkt_boundaries) :
         m_name(report_name.empty() ? name : report_name), m_desc(desc), m_bkt_boundaries(bkt_boundaries) {
+    RELEASE_ASSERT_LE(HistogramBuckets::num_buckets(bkt_boundaries), HistogramBuckets::max_hist_bkts,
+                      "Histogram '{}' supports at most {} boundaries, but {} were provided", name,
+                      HistogramBuckets::max_hist_bkts - 1, bkt_boundaries.size());
     if (!label_pair.first.empty() && !label_pair.second.empty()) { m_label_pair = label_pair; }
 }
 

--- a/src/metrics/tests/farm_test.cpp
+++ b/src/metrics/tests/farm_test.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -174,6 +175,30 @@ public:
 // Parameterized test fixture for DirectAccess tests
 class DirectAccessTest : public ::testing::TestWithParam< group_impl_type_t > {};
 
+class HistogramOverflowMetrics : public MetricsGroup {
+public:
+    HistogramOverflowMetrics(const char* inst_name, const group_impl_type_t type)
+        : MetricsGroup("HistogramOverflowGroup", inst_name, type) {
+        REGISTER_HISTOGRAM(overflow_histogram, "Overflow histogram", HistogramBucketsType(SteppedUpto32Buckets));
+        register_me_to_farm();
+    }
+    ~HistogramOverflowMetrics() { deregister_me_from_farm(); }
+};
+
+bool has_prometheus_sample(const std::string& output, const std::string& metric_name, const std::string& instance_name,
+                           const std::string& extra_label, const std::string& expected_value) {
+    std::istringstream lines{output};
+    std::string line;
+    while (std::getline(lines, line)) {
+        if (line.rfind(metric_name, 0) == 0 && line.find("entity=\"" + instance_name + "\"") != std::string::npos &&
+            (extra_label.empty() || line.find(extra_label) != std::string::npos) &&
+            line.ends_with(" " + expected_value)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Test direct access to counter, gauge, and histogram values
 TEST_P(DirectAccessTest, allMetricTypes) {
     group_impl_type_t impl_type = GetParam();
@@ -205,6 +230,27 @@ TEST_P(DirectAccessTest, allMetricTypes) {
     EXPECT_GT(stats.p50, 0.0);
     EXPECT_GT(stats.p95, 0.0);
     EXPECT_GT(stats.p99, 0.0);
+}
+
+TEST_P(DirectAccessTest, histogramOverflowBucket) {
+    const auto impl_type = GetParam();
+    HistogramOverflowMetrics metrics("histogram_overflow_test", impl_type);
+
+    constexpr int64_t highest_boundary{32};
+    HISTOGRAM_OBSERVE(metrics, overflow_histogram, highest_boundary - 1);
+    HISTOGRAM_OBSERVE(metrics, overflow_histogram, highest_boundary);
+    HISTOGRAM_OBSERVE(metrics, overflow_histogram, highest_boundary + 1);
+
+    const auto stats = HISTOGRAM_VALUE(metrics, overflow_histogram);
+    EXPECT_EQ(stats.count, 3);
+    EXPECT_DOUBLE_EQ(stats.average, 32.0);
+
+    const auto output = MetricsFarm::getInstance().report(ReportFormat::kTextFormat);
+    const auto& instance_name = metrics.instance_name();
+    EXPECT_TRUE(has_prometheus_sample(output, "overflow_histogram_bucket", instance_name, "le=\"32\"", "2"));
+    EXPECT_TRUE(has_prometheus_sample(output, "overflow_histogram_bucket", instance_name, "le=\"+Inf\"", "3"));
+    EXPECT_TRUE(has_prometheus_sample(output, "overflow_histogram_count", instance_name, "", "3"));
+    EXPECT_TRUE(has_prometheus_sample(output, "overflow_histogram_sum", instance_name, "", "96"));
 }
 
 INSTANTIATE_TEST_SUITE_P(AllImplementations, DirectAccessTest,


### PR DESCRIPTION
Histogram observations above the largest configured boundary use the implicit overflow bucket at index boundaries.size(). RCU and thread-buffer aggregation previously omitted that slot during merge, leaving the sum updated while count and the Prometheus +Inf bucket were too low. The atomic implementation discarded these observations entirely.

Account for the implicit overflow bucket in every implementation, validate that configured boundaries fit the fixed histogram storage, and cover below-boundary, exact-boundary, and overflow observations across all backends and Prometheus output.