### PR TITLE
SDSTOR-24888: Add inject_auth_metadata helper to GrpcSyncClient (v8.x)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,7 +9,7 @@ required_conan_version = ">=1.60.0"
 
 class SISLConan(ConanFile):
     name = "sisl"
-    version = "8.9.7"
+    version = "8.9.8"
     homepage = "https://github.com/eBay/sisl"
     description = "Library for fast data structures, utilities"
     topics = ("ebay", "components", "core", "efficiency")

--- a/include/sisl/grpc/rpc_client.hpp
+++ b/include/sisl/grpc/rpc_client.hpp
@@ -168,6 +168,11 @@ public:
     std::unique_ptr< typename ServiceT::StubInterface > MakeStub() {
         return ServiceT::NewStub(m_channel);
     }
+
+protected:
+    void inject_auth_metadata(::grpc::ClientContext& ctx) const {
+        if (m_trf_client) { ctx.AddMetadata("authorization", m_trf_client->get_typed_token()); }
+    }
 };
 
 ENUM(ClientState, uint8_t, VOID, INIT, RUNNING, SHUTTING_DOWN, TERMINATED)

--- a/src/grpc/tests/unit/auth_test.cpp
+++ b/src/grpc/tests/unit/auth_test.cpp
@@ -373,6 +373,13 @@ public:
 
     const std::unique_ptr< EchoService::StubInterface >& echo_stub() { return echo_stub_; }
 
+    // Simulates how a real sync client subclass uses inject_auth_metadata (analogous to OmClient::init_ctx).
+    ::grpc::Status call_echo(const EchoRequest& req, EchoReply& reply) {
+        ::grpc::ClientContext ctx;
+        inject_auth_metadata(ctx);
+        return echo_stub_->Echo(&ctx, req, &reply);
+    }
+
 private:
     std::unique_ptr< EchoService::StubInterface > echo_stub_;
 };
@@ -388,6 +395,30 @@ TEST_F(AuthEnableTest, allow_sync_client_with_auth) {
     auto status = sync_client->echo_stub()->Echo(&context, req, &reply);
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(req.message(), reply.message());
+}
+
+TEST_F(AuthEnableTest, sync_client_injects_auth_header) {
+    auto raw_token = TestToken().sign_rs256();
+    set_token_response(raw_token);
+    EchoAndPingClient sync_client{grpc_server_addr, m_trf_client, "", ""};
+    sync_client.init();
+    EchoRequest req;
+    EchoReply reply;
+    req.set_message("sync_inject_auth");
+    ::grpc::Status status = sync_client.call_echo(req, reply);
+    ASSERT_TRUE(status.ok()) << status.error_message();
+    EXPECT_EQ(req.message(), reply.message());
+}
+
+TEST_F(AuthServerOnlyTest, sync_client_no_token_is_noop) {
+    EchoAndPingClient sync_client{grpc_server_addr, "", ""};
+    sync_client.init();
+    EchoRequest req;
+    EchoReply reply;
+    req.set_message("sync_no_token");
+    ::grpc::Status status = sync_client.call_echo(req, reply);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.error_code(), ::grpc::UNAUTHENTICATED);
 }
 
 void validate_generic_reply(const std::string& method, ::grpc::Status& status) {


### PR DESCRIPTION
GrpcSyncClient held m_trf_client (inherited from GrpcBaseClient) but provided no mechanism to inject it into a ClientContext. Subclasses had to access the protected member directly, duplicating the null-check and AddMetadata call.

Add a protected inject_auth_metadata() that mirrors the auth injection already present in GrpcAsyncClient::AsyncStub::prepare_and_send_unary and GenericAsyncStub::prepare_and_send_unary_generic.